### PR TITLE
docs: add project governance, coding standards, and contributor guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,154 @@
+# GitHub Copilot — Project Instructions
+
+These instructions apply to GitHub Copilot, Copilot Chat, Copilot Workspace, and
+any Copilot-powered agent working on the SmartEVSE codebase.
+
+## Project Context
+
+SmartEVSE is safety-critical embedded firmware for an EV charging controller running
+on ESP32 and CH32 microcontrollers. Incorrect code can damage vehicles, trip breakers,
+or cause electrical hazards. Treat every change as if it controls a contactor
+switching 32A at 400V — because it does.
+
+## Mandatory Standards
+
+### Coding Conventions
+
+These are enforced by CI. Violations fail the build.
+
+- **Functions**: `snake_case` — `evse_tick_10ms()`, `mqtt_parse_command()`
+- **Global variables**: `CamelCase` — `ChargeDelay`, `ErrorFlags`, `State`
+- **Macros/constants**: `UPPER_SNAKE_CASE` — `MAX_MAINS`, `STATE_A`, `MODE_SOLAR`
+- **Typedefs/enums**: `CamelCase` — `EvseState`, `mqtt_command_t`
+- **C standard**: C11 for `.c` files
+- **Never use `sprintf`** — always `snprintf(buf, sizeof(buf), ...)`
+- **Never allocate heap in ISRs or critical sections** — no `malloc`, `new`, `String`
+- **Compiler warnings**: `-Wall -Wextra -Wunused-variable`, zero warnings
+
+### Architecture Rules
+
+1. **`evse_state_machine.c` is pure C.** No Arduino, ESP-IDF, or FreeRTOS includes.
+   It must compile with plain `gcc` on any host. All hardware interaction goes
+   through `evse_ctx_t` and `evse_hal_t` callbacks.
+
+2. **Bridge pattern for globals.** Firmware globals are synced to/from `evse_ctx_t`
+   via `evse_bridge.cpp` inside spinlock-protected critical sections. Never read or
+   write `evse_ctx_t` from outside the bridge without synchronization.
+
+3. **Pure C modules for parsing/validation.** `mqtt_parser.c` and `http_api.c` have
+   no Arduino dependencies. New parsing or validation logic must follow the same
+   pattern — pure C with `extern "C"` guards in the header.
+
+4. **Thin glue layer.** `esp32.cpp` dispatches MQTT/HTTP callbacks to pure modules.
+   Push logic into the pure modules, keep the glue minimal.
+
+5. **Platform guards.** Use `#ifdef SMARTEVSE_VERSION` only in bridge/glue layers,
+   never in `evse_state_machine.c` or parser modules.
+
+### Test-First Workflow
+
+Every code change must follow this sequence:
+
+```
+1. Write SbE specification (Given/When/Then)
+2. Write the test with @feature, @req, @scenario annotations
+3. Implement the code change
+4. Run: cd SmartEVSE-3/test/native && make clean test
+5. Verify: pio run -e release -d SmartEVSE-3/
+```
+
+**Never write implementation code without a corresponding test.**
+
+### SbE Test Annotations
+
+Every test function must have this comment block:
+
+```c
+/*
+ * @feature Feature Name
+ * @req REQ-AREA-NNN
+ * @scenario What this test verifies
+ * @given Precondition
+ * @when Action or trigger
+ * @then Expected outcome
+ */
+void test_descriptive_name(void) { ... }
+```
+
+Requirement ID prefixes: `REQ-SM-` (state machine), `REQ-ERR-` (error/safety),
+`REQ-LB-` (load balancing), `REQ-SOL-` (solar), `REQ-MQTT-` (MQTT),
+`REQ-API-` (HTTP), `REQ-AUTH-` (authorization), `REQ-MOD-` (modem),
+`REQ-PH-` (phase switching), `REQ-PWR-` (power), `REQ-E2E-` (end-to-end).
+
+Check `SmartEVSE-3/test/native/test-specification.md` for existing IDs.
+
+### Defensive Programming
+
+- Validate all external inputs (MQTT payloads, HTTP parameters, Modbus data)
+  before passing to the state machine or writing to globals.
+- Use bounds checking on array indices, especially `BalancedState[]` (0-7 nodes),
+  mains phase arrays (0-2), and RFID arrays.
+- Check return values from `snprintf` — if it returns >= buffer size, the output
+  was truncated.
+- Never trust payload lengths from network sources. Always cap to buffer size.
+
+### Memory Awareness
+
+- ESP32: 1,640KB flash (95% budget), 288KB RAM (90% budget)
+- CH32: 61KB flash (95% budget), 18KB RAM (90% budget)
+- New static buffers must be justified. Prefer stack allocation for temporary buffers.
+- Test code compiles only in the native test harness, never in firmware builds.
+- Arduino `String` is acceptable in non-safety glue code (MQTT publish, JSON).
+  Do not convert existing `String` usage to `char[]` — it risks truncation bugs.
+
+## File Safety Levels
+
+| Risk | Files | Rule |
+|------|-------|------|
+| CRITICAL | `evse_state_machine.c`, `evse_ctx.h` | Must add tests for any change |
+| HIGH | `evse_bridge.cpp`, test files, Makefile | Review carefully |
+| MEDIUM | `mqtt_parser.c`, `http_api.c`, `esp32.cpp` | Follow module patterns |
+| LOW | `glcd.cpp`, `network_common.cpp` | Standard care |
+
+## Code Generation Guidelines
+
+When generating code for this project:
+
+- Match the style of surrounding code exactly
+- Use `Arrange / Act / Assert` pattern in tests with clear comments
+- Include units in variable names or comments: `current_dA` (deci-amps),
+  `power_W` (watts), `energy_Wh` (watt-hours)
+- Prefer explicit state over implicit: set all relevant context fields in tests
+- Add negative test cases for every positive case (invalid input, boundary values)
+- When suggesting fixes to `evse_state_machine.c`, always include the test diff
+
+## Multi-Agent Coordination
+
+When Copilot Workspace or multiple agents operate concurrently:
+
+- One agent must act as **Quality Guardian** — reviewing all changes for standard
+  compliance, running tests, and verifying builds. It does not write implementation
+  code.
+- Implementation agents work on non-overlapping files.
+- No agent modifies `evse_state_machine.c` without also modifying test files.
+- All agents must read `CODING_STANDARDS.md` and `CONTRIBUTING.md` before starting.
+- Changes are merged sequentially, not simultaneously, to avoid conflicts.
+
+## Quick Reference
+
+```bash
+# Run tests
+cd SmartEVSE-3/test/native && make clean test
+
+# Build firmware
+pio run -e release -d SmartEVSE-3/
+pio run -e ch32 -d SmartEVSE-3/
+
+# Regenerate test spec
+cd SmartEVSE-3/test/native && python3 scripts/extract_traceability.py \
+  --markdown test-specification.md
+
+# Run with memory sanitizers
+cd SmartEVSE-3/test/native && make clean test \
+  CFLAGS_EXTRA="-fsanitize=address,undefined -fno-omit-frame-pointer"
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,238 @@
+# Claude Code — Project Instructions
+
+This file configures Claude Code (and any Claude-based agent) when working on the
+SmartEVSE codebase. Read this entire file before making any changes.
+
+## Project Overview
+
+SmartEVSE is an open-source Electric Vehicle Supply Equipment (EVSE) controller.
+The firmware runs on ESP32 (v3/v4) and CH32 microcontrollers. This is safety-critical
+embedded software — incorrect behavior can damage vehicles, trip breakers, or cause
+electrical hazards.
+
+## Critical Rules
+
+### Safety First
+
+- **Never modify `evse_state_machine.c` without adding or updating tests.** This
+  module controls contactors, CP pilot signals, and current limiting. Every change
+  must have a corresponding test in `SmartEVSE-3/test/native/tests/`.
+- **Never bypass error checks or safety validations.** Do not remove or weaken
+  bounds checking, overcurrent protection, or state machine guard conditions.
+- **Never use `sprintf`.** Always use `snprintf` with explicit buffer sizes.
+- **Never allocate heap memory in ISRs, timer callbacks, or critical sections.**
+  No `malloc`, `new`, Arduino `String`, or any blocking call inside
+  `portENTER_CRITICAL` / `portEXIT_CRITICAL` blocks.
+- **Never add `#ifdef` platform guards in core logic.** Use the bridge layer
+  (`evse_bridge.h`) to keep platform-specific code out of `evse_state_machine.c`.
+
+### Specification-First Workflow
+
+This project follows a strict test-first workflow. When implementing any change:
+
+1. **Write the SbE specification first** — describe the expected behavior using
+   Given/When/Then before writing any implementation code.
+2. **Write the test** — create or extend a test file in
+   `SmartEVSE-3/test/native/tests/` with full SbE annotations.
+3. **Then implement** — make the code change so the test passes.
+4. **Verify** — run `cd SmartEVSE-3/test/native && make clean test` to confirm
+   all tests pass (not just the new one).
+
+Never skip the test. Never write implementation code without a corresponding test.
+
+### SbE Annotation Format
+
+Every test function MUST have a block comment with these annotations:
+
+```c
+/*
+ * @feature Feature Name
+ * @req REQ-AREA-NNN
+ * @scenario What this test verifies
+ * @given Precondition
+ * @when Action or trigger
+ * @then Expected outcome
+ */
+void test_descriptive_name(void) { ... }
+```
+
+Use existing feature names and requirement prefixes from
+`SmartEVSE-3/test/native/test-specification.md`. Requirement ID prefixes:
+
+- `REQ-SM-` State machine, `REQ-ERR-` Error/safety, `REQ-LB-` Load balancing
+- `REQ-SOL-` Solar, `REQ-OCPP-` OCPP, `REQ-MQTT-` MQTT, `REQ-API-` HTTP API
+- `REQ-AUTH-` Authorization, `REQ-MOD-` Modem/ISO15118, `REQ-PH-` Phase switching
+- `REQ-MTR-` Metering, `REQ-PWR-` Power, `REQ-E2E-` End-to-end
+- `REQ-DUAL-` Dual-EVSE, `REQ-MULTI-` Multi-node
+
+## Architecture
+
+### Module Structure
+
+```
+evse_state_machine.c    Pure C state machine — NO platform dependencies
+evse_ctx.h              Context struct (evse_ctx_t) — all state in one place
+evse_bridge.h/cpp       Syncs firmware globals <-> evse_ctx_t (spinlock-protected)
+mqtt_parser.h/c         Pure C MQTT command parsing — no Arduino dependency
+http_api.h/c            Pure C HTTP validation — no Arduino dependency
+firmware_manager.h/cpp  OTA update logic — extracted from network_common.cpp
+esp32.cpp               Firmware glue: callbacks, dispatchers, hardware I/O
+network_common.cpp      WiFi, MQTT client, HTTP server (Mongoose)
+```
+
+### Key Architectural Principles
+
+1. **Pure C modules for testability.** Parsing, validation, and state machine logic
+   must compile and test natively with `gcc` on any host. No Arduino, ESP-IDF, or
+   FreeRTOS dependencies in these modules.
+
+2. **Thin glue layer.** `esp32.cpp` and `network_common.cpp` are thin dispatchers
+   that convert Arduino types to C types and call pure modules. Keep glue code
+   minimal — push logic into the pure modules.
+
+3. **Snapshot structs.** Pure functions operate on struct snapshots (e.g.,
+   `evse_ctx_t`, `http_settings_request_t`, `mqtt_command_t`), never on globals
+   directly.
+
+4. **Bridge pattern.** `evse_bridge.cpp` syncs globals to/from `evse_ctx_t` inside
+   spinlock-protected critical sections. Never access `evse_ctx_t` fields from
+   outside the bridge without synchronization.
+
+5. **Platform guards.** Use `#ifdef SMARTEVSE_VERSION` (30 or 40) only in the bridge
+   and glue layers, never in `evse_state_machine.c` or parser modules.
+
+### Memory Budget
+
+| Target | Flash budget | RAM budget | Current |
+|--------|-------------|-----------|---------|
+| ESP32  | 95% (1,640KB) | 90% (288KB) | ~84% / ~21% |
+| CH32   | 95% (61KB)   | 90% (18KB)  | ~59% / ~19% |
+
+Before merging, verify: `pio run -e release -d SmartEVSE-3/` and
+`pio run -e ch32 -d SmartEVSE-3/` both compile within budget. CI enforces this.
+
+## Coding Conventions
+
+Read `CODING_STANDARDS.md` for the full reference. Key rules:
+
+- **Functions**: `snake_case` — `evse_tick_10ms()`, `mqtt_parse_command()`
+- **Globals**: `CamelCase` — `ChargeDelay`, `ErrorFlags`, `State`
+- **Macros/constants**: `UPPER_SNAKE_CASE` — `MAX_MAINS`, `STATE_A`, `MODE_SOLAR`
+- **Typedefs/enums**: `CamelCase` — `EvseState`, `mqtt_command_t`
+- **C standard**: C11 (`-std=c11`) for `.c` files
+- **Compiler warnings**: `-Wall -Wextra -Wunused-variable` — zero warnings policy
+- **Buffer writes**: always `snprintf(buf, sizeof(buf), ...)`, never `sprintf`
+- **Critical sections**: < 10 us, no blocking calls, use spinlocks
+
+## Verification Commands
+
+```bash
+# Run all native tests (must pass before any PR)
+cd SmartEVSE-3/test/native && make clean test
+
+# Build ESP32 firmware
+pio run -e release -d SmartEVSE-3/
+
+# Build CH32 firmware
+pio run -e ch32 -d SmartEVSE-3/
+
+# Regenerate test specification
+cd SmartEVSE-3/test/native && python3 scripts/extract_traceability.py \
+  --markdown test-specification.md --html traceability-report.html
+
+# Run with sanitizers (catches memory bugs)
+cd SmartEVSE-3/test/native && make clean test \
+  CFLAGS_EXTRA="-fsanitize=address,undefined -fno-omit-frame-pointer"
+```
+
+## Multi-Agent Workflow
+
+When multiple AI agents work on this codebase simultaneously, one agent MUST act
+as the **Quality Guardian**. This applies to Claude Code with parallel Task agents,
+multi-agent orchestration, or any setup where more than one agent writes code.
+
+### Quality Guardian Role
+
+The Quality Guardian agent does NOT write implementation code. Its responsibilities:
+
+1. **Review every code change** before it is committed:
+   - Naming conventions match (`snake_case` functions, `CamelCase` globals)
+   - No `sprintf`, no heap allocation in critical paths
+   - State machine changes have corresponding tests
+   - SbE annotations are present and well-formed on all test functions
+   - No direct global access bypassing the bridge layer
+   - `extern "C"` guards present on all `.h` files included from both C and C++
+
+2. **Run the test suite** after each implementation agent finishes:
+   ```bash
+   cd SmartEVSE-3/test/native && make clean test
+   ```
+
+3. **Run the firmware build** to verify compilation:
+   ```bash
+   pio run -e release -d SmartEVSE-3/
+   pio run -e ch32 -d SmartEVSE-3/
+   ```
+
+4. **Regenerate and verify traceability**:
+   ```bash
+   cd SmartEVSE-3/test/native && python3 scripts/extract_traceability.py \
+     --markdown test-specification.md
+   ```
+   Verify new tests appear with correct feature names and requirement IDs.
+
+5. **Check memory budget** — flash and RAM usage must stay within budget limits
+   shown above.
+
+6. **Reject changes that violate these standards.** The Quality Guardian has veto
+   authority. Non-compliant code must be fixed before merging.
+
+### Implementation Agent Rules
+
+Agents that write code must:
+
+- Read this file (`CLAUDE.md`) and `CODING_STANDARDS.md` before starting
+- Follow the specification-first workflow (SbE -> test -> code)
+- Not modify files outside their assigned scope without coordination
+- Not commit directly — submit changes for Quality Guardian review
+- Not modify `evse_state_machine.c` without adding tests in the same changeset
+- Run `make clean test` locally before declaring work complete
+
+### Coordination Protocol
+
+When dividing work across agents:
+
+- Assign non-overlapping files to each implementation agent
+- The Quality Guardian reviews all changes in sequence, not in parallel
+- If two agents need to modify the same file, one waits for the other to finish
+- Merge conflicts are resolved by the Quality Guardian, preserving both changes
+- Each agent's changes are verified independently before combining
+
+## Files You Should Know
+
+| File | Purpose | Safety level |
+|------|---------|-------------|
+| `evse_state_machine.c` | Core state machine | CRITICAL — test every change |
+| `evse_ctx.h` | State context struct | CRITICAL — field changes affect everything |
+| `evse_bridge.cpp` | Global-to-context sync | HIGH — spinlock-protected |
+| `esp32.cpp` | Firmware glue, callbacks | MEDIUM — dispatchers only |
+| `mqtt_parser.c` | MQTT command parsing | MEDIUM — input validation |
+| `http_api.c` | HTTP request validation | MEDIUM — input validation |
+| `network_common.cpp` | WiFi, MQTT, HTTP server | LOW — network plumbing |
+| `glcd.cpp` | LCD display | LOW — cosmetic only |
+| `test/native/tests/` | All native test suites | HIGH — test integrity |
+| `test/native/Makefile` | Test build system | HIGH — must compile all suites |
+
+## What NOT to Do
+
+- Do not refactor Arduino `String` to `char[]` in non-safety code — it works, and
+  replacing it risks payload truncation with no benefit on ESP32's 320KB RAM.
+- Do not add `#include` dependencies from `evse_state_machine.c` to Arduino or
+  ESP-IDF headers — this module must compile natively.
+- Do not add FreeRTOS task creation or stack allocation without checking the memory
+  budget and documenting stack size rationale.
+- Do not remove or weaken existing test assertions — tests are the safety net.
+- Do not "improve" code that wasn't part of the assigned task. Stay focused.
+- Do not manually commit generated files (`traceability-report.html`,
+  `test-specification.md`) — CI auto-generates and commits both on every merge
+  to master. Both are tracked in the repo.

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,121 @@
+# Coding Standards
+
+This document codifies the conventions used across the SmartEVSE codebase.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for workflow and submission guidelines.
+
+## C Code Style
+
+- **Standard**: C11 (`-std=c11`)
+- **Functions**: `snake_case` — e.g. `evse_state_machine_run()`, `get_charge_current()`
+- **Global variables**: `CamelCase` — e.g. `ChargeDelay`, `ErrorFlags`, `State`
+- **Macros / constants**: `UPPER_SNAKE_CASE` — e.g. `MAX_MAINS`, `STATE_A`
+- **Typedefs / enums**: `CamelCase` — e.g. `EvseState`, `ProximityPin`
+- **Compiler warnings**: `-Wall -Wextra -Wunused-variable` enabled for all targets
+- **Formatting**: match surrounding code; no hard line-length limit but keep it readable
+
+## Buffer Safety
+
+- Use `snprintf` instead of `sprintf` — all buffer-writing functions must take a size
+  parameter to prevent overflows.
+- String formatting functions follow the pattern:
+  ```c
+  int format_status(char *buf, size_t len, ...);
+  ```
+- Never assume a buffer is "big enough" — always pass and check the size.
+
+## FreeRTOS Conventions
+
+- **Short critical sections**: use `portENTER_CRITICAL` / `portEXIT_CRITICAL` with
+  spinlocks for shared-variable access (< 10 µs).
+- **No heap allocation in ISRs or timer callbacks**: avoid `String`, `malloc`, or any
+  function that may block.
+- **Task priorities**: follow existing priority assignments; document deviations.
+- **Spinlock pattern** (ESP32):
+  ```c
+  static portMUX_TYPE my_mux = portMUX_INITIALIZER_UNLOCKED;
+  portENTER_CRITICAL(&my_mux);
+  shared_var = new_value;
+  portEXIT_CRITICAL(&my_mux);
+  ```
+
+## Platform Guards
+
+The codebase targets both ESP32 (v3/v4) and CH32. Use the established guard pattern:
+
+```c
+#ifdef SMARTEVSE_VERSION
+    // ESP32-specific code (SMARTEVSE_VERSION is 30 or 40)
+#else
+    // CH32-specific code
+#endif
+```
+
+The bridge layer (`evse_state_machine.c` + `evse_bridge.h`) keeps platform-specific
+code out of core logic. New state-machine logic should go through bridge functions
+rather than using `#ifdef` directly.
+
+## Module Extraction Pattern
+
+When extracting testable modules from monolithic files, follow this pattern:
+
+1. **Pure C modules for parsing/validation** — no Arduino or ESP32 dependencies:
+   ```c
+   // mqtt_parser.h — data types and pure functions
+   bool mqtt_parse_command(const char *prefix, const char *topic,
+                           const char *payload, mqtt_command_t *out);
+   ```
+   These compile and test natively with GCC on the host.
+
+2. **Firmware glue layer** — thin dispatchers that call the pure module:
+   ```cpp
+   // In esp32.cpp — the callback becomes a thin wrapper
+   void mqtt_receive_callback(const String topic, const String payload) {
+       mqtt_command_t cmd;
+       if (!mqtt_parse_command(prefix, topic.c_str(), payload.c_str(), &cmd))
+           return;
+       switch (cmd.cmd) { /* dispatch to setMode(), setOverrideCurrent(), etc. */ }
+   }
+   ```
+   The glue layer handles Arduino types, globals, and hardware I/O.
+
+3. **Snapshot structs** for decoupling from globals:
+   ```c
+   // http_api.h — snapshot of state needed by pure functions
+   typedef struct {
+       bool has_mode;  int mode;
+       bool has_current; int current;
+   } http_settings_request_t;
+   ```
+   Pure functions operate on snapshots, not global variables.
+
+**Benefits**: Pure C modules are testable without hardware, have explicit
+dependencies, and their validation logic can be verified at compile time
+rather than discovered via field failures.
+
+## Testing
+
+- **Framework**: native C tests compiled with GCC, run on the host (no hardware needed).
+- **SbE annotations**: all test functions must include Specification-by-Example tags:
+  ```c
+  // @feature State Machine
+  // @req REQ-SM-001
+  // @scenario Normal charging cycle
+  // @given Vehicle connected in state B
+  // @when Pilot duty cycle allows charging
+  // @then State transitions to C and contactor closes
+  void test_normal_charge_cycle(void) { ... }
+  ```
+- **All tests must pass** before submitting a PR: `make clean test`
+- **Safety-critical changes** (state machine, contactors, current limiting) require
+  thorough test coverage — add both positive and negative test cases.
+- **BDD tests**: feature files in `test/native/features/` with step definitions in
+  `test/native/steps/`.
+
+## Versioning
+
+- Format: `vMAJOR.MINOR.PATCH[-prerelease]` (e.g. `v3.11.0`, `v3.11.1-rc1`)
+- The `VERSION` macro is defined in `platformio.ini` (`-DVERSION=...`) and falls back
+  to a build timestamp in `debug.h` if not set.
+- The `-dev` suffix marks unreleased development builds.
+- CI validates that git tags match the VERSION in `platformio.ini` on release.
+- See [CONTRIBUTING.md](CONTRIBUTING.md#versioning) for bump rules and release flow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,369 @@
+# Contributing to SmartEVSE
+
+Thank you for your interest in contributing to SmartEVSE! This document provides guidelines for contributing to the project.
+
+## Getting Started
+
+1. Fork the repository on GitHub
+2. Clone your fork locally
+3. Create a feature branch from `master`
+
+## Development Setup
+
+### Prerequisites
+
+- [PlatformIO](https://platformio.org/) for firmware builds
+- GCC (C11) for native tests
+- Python 3.10+ for test tooling
+
+### Building Firmware
+
+```bash
+# ESP32 v3
+pio run -e release -d SmartEVSE-3/
+
+# CH32
+pio run -e ch32 -d SmartEVSE-3/
+```
+
+### Running Tests
+
+```bash
+cd SmartEVSE-3/test/native
+make clean test
+```
+
+All 424 native tests (across 19 suites) must pass before submitting a PR.
+
+## Making Changes
+
+### Branch Naming
+
+- `feature/short-description` for new features
+- `fix/short-description` for bug fixes
+- `docs/short-description` for documentation changes
+
+### Commit Messages
+
+Use clear, concise commit messages:
+
+```
+Add solar mode phase switching logic
+
+Implements automatic 3P-to-1P switching when solar surplus drops
+below threshold for 10 seconds.
+```
+
+- Use imperative mood ("Add", not "Added")
+- First line under 72 characters
+- Add a blank line and details if needed
+
+### Code Style
+
+- C source files: C11 standard
+- Use existing code patterns as reference
+- Keep functions focused and testable
+- Add SbE annotations (`@feature`, `@req`, `@scenario`, `@given`, `@when`, `@then`) to new test functions
+
+### Testing Requirements
+
+- Add tests for new functionality
+- Ensure all existing tests pass (`make clean test`)
+- Safety-critical changes (state machine, contactors, current limiting) require thorough test coverage
+- Add SbE annotations to all new test functions (see below)
+- After adding tests, regenerate the specification to verify traceability:
+  ```bash
+  cd SmartEVSE-3/test/native
+  python3 scripts/extract_traceability.py --markdown test-specification.md
+  ```
+
+### Specification by Example (SbE)
+
+Every test function must include structured comment annotations that link the test
+to a feature, requirement, and scenario. This enables automated traceability
+reporting — the CI pipeline generates a
+[test specification](SmartEVSE-3/test/native/test-specification.md) and an HTML
+traceability matrix from these annotations on every build.
+
+```c
+/*
+ * @feature State Machine
+ * @req REQ-SM-001
+ * @scenario Normal charging cycle
+ * @given Vehicle connected in state B
+ * @when Pilot duty cycle allows charging
+ * @then State transitions to C and contactor closes
+ */
+void test_normal_charge_cycle(void) { ... }
+```
+
+The CI traceability job validates that all annotated tests have requirement IDs and
+uploads the reports as build artifacts. See the
+[test specification](SmartEVSE-3/test/native/test-specification.md) for the full
+list of 410 scenarios across 31 features.
+
+## Reporting Findings & Proposing Improvements
+
+Whether you've found a bug or want to propose a functional improvement, the project
+follows a **specification-first** workflow: describe the expected behavior in SbE
+format, write the test, then make the code change. This ensures every change is
+traceable and verifiable.
+
+### Step 1: Describe the finding in SbE format
+
+Before writing any code, describe what you observed (bug) or what you want to achieve
+(improvement) using the Given/When/Then pattern. This forces clear thinking about
+preconditions, triggers, and expected outcomes.
+
+**Bug report example** — the EVSE doesn't stop charging when mains current exceeds
+the limit:
+
+```
+Feature:  Error Handling & Safety
+Req:      REQ-ERR-030
+Scenario: Charging stops when mains sum exceeds maximum
+
+Given  The EVSE is charging in Normal mode at 16A
+And    MaxSumMains is configured to 25A
+When   The mains meter reports L1=15A, L2=8A, L3=10A (sum=33A)
+Then   The charging current is reduced or paused
+And    An error condition is flagged
+```
+
+**Feature request example** — add a grace period before solar mode stops charging:
+
+```
+Feature:  Solar Balancing
+Req:      REQ-SOL-025
+Scenario: Solar stop timer provides grace period before stopping
+
+Given  The EVSE is charging in Solar mode
+And    The solar stop timer is set to 10 minutes
+When   Grid import exceeds solar_max_import
+Then   A countdown timer starts
+And    Charging continues during the countdown
+And    Charging stops only after the timer expires
+```
+
+Tips for writing good specifications:
+
+- **Be specific with values** — use concrete numbers (16A, 25A, 10 minutes), not
+  vague terms ("high current", "a while")
+- **One behavior per scenario** — if you need "And" in your "When", consider
+  splitting into two scenarios
+- **Cover the negative case too** — if something should happen at a threshold,
+  also specify what happens below that threshold
+- **Use existing feature names** — check the
+  [test specification](SmartEVSE-3/test/native/test-specification.md) for the list
+  of established feature names and requirement ID prefixes
+
+### Step 2: Choose a requirement ID
+
+Requirement IDs follow the pattern `REQ-{AREA}-{NUMBER}`. Check existing IDs in the
+[test specification](SmartEVSE-3/test/native/test-specification.md) and pick the
+next available number for your area:
+
+| Prefix | Area |
+|--------|------|
+| `REQ-SM-` | State machine transitions |
+| `REQ-ERR-` | Error handling & safety |
+| `REQ-LB-` | Load balancing |
+| `REQ-SOL-` | Solar mode / solar balancing |
+| `REQ-OCPP-` | OCPP integration |
+| `REQ-MQTT-` | MQTT command parsing |
+| `REQ-API-` | HTTP REST API |
+| `REQ-AUTH-` | Authorization & access control |
+| `REQ-MOD-` | Modem / ISO15118 |
+| `REQ-PH-` | Phase switching |
+| `REQ-MTR-` | Metering |
+| `REQ-PWR-` | Power availability |
+| `REQ-E2E-` | End-to-end charging flows |
+| `REQ-DUAL-` | Dual-EVSE scenarios |
+| `REQ-MULTI-` | Multi-node load balancing |
+
+### Step 3: Write the test BEFORE changing code
+
+Create or extend a test file in `SmartEVSE-3/test/native/tests/`. The test should
+**fail** initially (or not compile if the feature doesn't exist yet) — this confirms
+the test actually validates something.
+
+```c
+/*
+ * @feature Error Handling & Safety
+ * @req REQ-ERR-030
+ * @scenario Charging stops when mains sum exceeds maximum
+ * @given The EVSE is charging in Normal mode at 16A
+ * @given MaxSumMains is configured to 25A
+ * @when The mains meter reports L1=15A, L2=8A, L3=10A (sum=33A)
+ * @then The charging current is reduced or paused
+ */
+void test_mains_overcurrent_triggers_reduction(void) {
+    // Arrange
+    evse_state_machine_ctx_t ctx;
+    evse_state_machine_init(&ctx);
+    ctx.mode = MODE_NORMAL;
+    ctx.state = STATE_C;            // charging
+    ctx.charge_current = 160;       // 16.0A
+    ctx.max_sum_mains = 250;        // 25.0A
+
+    // Act — simulate meter reading that exceeds limit
+    ctx.mains_currents[0] = 150;    // L1 = 15.0A
+    ctx.mains_currents[1] = 80;     // L2 = 8.0A
+    ctx.mains_currents[2] = 100;    // L3 = 10.0A
+    evse_state_machine_run(&ctx);
+
+    // Assert
+    assert(ctx.charge_current < 160 || ctx.state != STATE_C);
+}
+```
+
+Run the test to confirm it fails or validates the fix:
+
+```bash
+cd SmartEVSE-3/test/native
+make clean test
+```
+
+### Step 4: Make the code change
+
+Now implement the fix or feature. The test you wrote in Step 3 tells you exactly
+when you're done — it passes.
+
+### Step 5: Regenerate the specification and verify
+
+```bash
+cd SmartEVSE-3/test/native
+python3 scripts/extract_traceability.py --markdown test-specification.md --html traceability-report.html
+```
+
+Check that your new scenario appears in the test specification under the correct
+feature, with the requirement ID you chose.
+
+### Step 6: Submit the PR
+
+Your PR should include:
+1. The test file(s) with SbE annotations
+2. The code change
+3. The updated `test-specification.md` (CI will also regenerate this automatically
+   on merge to master)
+
+The CI pipeline will verify that all tests pass, generate fresh traceability reports,
+and commit the updated test specification back to the repository.
+
+### Workflow summary
+
+```
+Finding/Idea → SbE description → Write failing test → Fix code → Test passes → PR
+```
+
+This is the opposite of the traditional "fix first, test maybe later" approach. By
+writing the specification and test first, you:
+
+- Force yourself to clearly define the expected behavior
+- Create a permanent, executable record of the requirement
+- Enable automated traceability from requirement to test to code
+- Make it easy for reviewers to understand what the change does and why
+
+## Versioning
+
+This project uses [semantic versioning](https://semver.org/): `vMAJOR.MINOR.PATCH[-prerelease]`
+
+### Bump Rules
+
+- **Patch** (`v3.11.0` → `v3.11.1`): bug fixes, documentation, test-only changes
+- **Minor** (`v3.11.1` → `v3.12.0`): new features, non-breaking enhancements
+- **Major** (`v3.12.0` → `v4.0.0`): breaking changes (config format, API, protocol)
+
+### Development Builds
+
+The VERSION in `platformio.ini` carries a `-dev` suffix (e.g. `v3.11.0-dev`) between
+releases. Local builds display this version on the LCD and web interface.
+
+### Release Flow
+
+1. Update VERSION in `SmartEVSE-3/platformio.ini` — remove the `-dev` suffix
+   (e.g. `v3.11.0-dev` → `v3.11.0`)
+2. Commit: `Release v3.11.0`
+3. Tag: `git tag v3.11.0`
+4. Push: `git push origin master --tags`
+5. CI validates the tag matches `platformio.ini` and builds the release
+6. Bump VERSION for next development cycle (e.g. `v3.11.1-dev`), commit, push
+
+## Submitting Changes
+
+1. Push your branch to your fork
+2. Open a Pull Request against `master`
+3. Describe what your changes do and why
+4. Reference any related issues
+5. Ensure CI checks pass
+
+## Reporting Bugs
+
+Use the [bug report template](https://github.com/dingo35/SmartEVSE-3.5/issues/new?template=bug_report.md) and include:
+
+- Your SmartEVSE hardware version (v3 or v4)
+- Firmware version
+- Configuration JSON (from the webserver "raw" button)
+- Debug log capturing the issue
+
+## AI-Assisted Development
+
+This project supports contributions made with AI coding agents. Configuration files
+are provided for both Claude Code and GitHub Copilot to ensure agents follow project
+standards automatically.
+
+### Setup
+
+| Agent | Configuration file | How to use |
+|-------|-------------------|------------|
+| Claude Code | [`CLAUDE.md`](CLAUDE.md) | Auto-loaded when Claude Code opens the repo |
+| GitHub Copilot | [`.github/copilot-instructions.md`](.github/copilot-instructions.md) | Auto-loaded by Copilot Chat and Copilot Workspace |
+
+Both files encode the same rules: coding conventions, architectural principles,
+test-first workflow, memory budgets, and safety constraints. The agent-specific
+files format these rules in the way each tool consumes them best.
+
+### Quality Guardian Pattern
+
+When using multiple AI agents simultaneously (e.g., Claude Code's parallel Task
+agents, or Copilot Workspace with multiple agents), designate one agent as the
+**Quality Guardian**:
+
+- The Quality Guardian **does not write implementation code**
+- It reviews every change from other agents for compliance with:
+  - Naming conventions (`snake_case` functions, `CamelCase` globals)
+  - SbE annotations on all test functions
+  - No `sprintf`, no heap allocation in critical sections
+  - State machine changes paired with corresponding tests
+  - `extern "C"` guards on headers shared between C and C++
+- It runs the test suite and firmware builds after each agent completes
+- It regenerates the test specification and verifies traceability
+- It has veto authority — non-compliant code must be fixed before merging
+
+### Single Agent Workflow
+
+When working with a single AI agent, it must self-enforce the Quality Guardian
+checklist before marking work complete:
+
+1. All tests pass (`make clean test`)
+2. Firmware compiles (`pio run -e release`, `pio run -e ch32`)
+3. New tests have SbE annotations with valid requirement IDs
+4. No coding standard violations in changed files
+5. Test specification regenerated if tests were added
+
+### What to Watch For
+
+AI agents may:
+- Generate `sprintf` instead of `snprintf` — always reject this
+- Skip writing tests for "simple" changes — always require tests
+- Add unnecessary abstractions or over-engineer — keep changes minimal
+- Use incorrect naming conventions — check against `CODING_STANDARDS.md`
+- Modify files outside their assigned scope — enforce file boundaries
+
+## Security Vulnerabilities
+
+Please report security vulnerabilities privately. See [SECURITY.md](SECURITY.md) for details.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -64,6 +64,61 @@ After updating the firmware, you can access the status page again using the norm
 [Configuration](docs/configuration.md)<br>
 [Operation](docs/operation.md)<br>
 [Building and Flashing the firmware](docs/building_flashing.md)<br>
+[REST API reference](docs/REST_API.md)<br>
+[Coding standards](CODING_STANDARDS.md)<br>
+[Contributing](CONTRIBUTING.md)<br>
+[AI agent instructions (Claude Code)](CLAUDE.md)<br>
+[AI agent instructions (GitHub Copilot)](.github/copilot-instructions.md)<br>
+
+# Testing & Quality
+
+The firmware is verified by a comprehensive native test suite that runs on the host
+(no hardware required) and an 8-job CI pipeline.
+
+| Metric | Value |
+|--------|-------|
+| Test suites | 19 |
+| Test scenarios | 410 |
+| Features covered | 31 |
+| Requirement traceability | 100% |
+
+**Test areas** include IEC 61851-1 state transitions, load balancing (single and
+multi-node), Smart/Solar operating modes, OCPP current limiting, MQTT command
+parsing, HTTP API validation, error handling & safety, modem/ISO15118 negotiation,
+phase switching, and end-to-end charging flows.
+
+Every test function carries Specification-by-Example (SbE) annotations (`@feature`,
+`@req`, `@scenario`, `@given`/`@when`/`@then`) that trace back to requirements. The
+CI pipeline generates two reports on every build:
+
+- **[Test Specification](SmartEVSE-3/test/native/test-specification.md)** — Markdown
+  document listing all scenarios grouped by feature, with requirement IDs and
+  Given/When/Then steps. Auto-regenerated and committed on every merge to master.
+- **[Traceability Report](SmartEVSE-3/test/native/traceability-report.html)** — Interactive HTML matrix
+  mapping requirements to test functions. Auto-regenerated and committed on every
+  merge to master. Also attached to every GitHub release.
+
+Additional CI artifacts:
+
+| Artifact | Description |
+|----------|-------------|
+| `coverage-report` | Line coverage for the state machine module (lcov) |
+| `traceability-reports` | HTML + Markdown specification reports |
+| `bdd-report` | BDD feature test results (pytest-bdd HTML) |
+
+To run the test suite locally:
+
+```bash
+cd SmartEVSE-3/test/native
+make clean test
+```
+
+To generate the specification and traceability reports locally:
+
+```bash
+cd SmartEVSE-3/test/native
+python3 scripts/extract_traceability.py --html traceability-report.html --markdown test-specification.md
+```
 
 # SmartEVSE App
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in SmartEVSE, please report it responsibly through GitHub's private vulnerability reporting feature:
+
+1. Go to the **Security** tab of this repository
+2. Click **Report a vulnerability**
+3. Fill in the details of the vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+## What to Report
+
+SmartEVSE is an internet-connected device that controls mains electricity. Security issues of particular concern include:
+
+- Remote code execution via WiFi, MQTT, REST API, or OCPP interfaces
+- Authentication bypass on the web interface or RFID system
+- Firmware update integrity issues (unsigned or tampered OTA updates)
+- Modbus communication spoofing that could affect charging safety
+- Denial of service that could leave contactors in an unsafe state
+- Information disclosure of WiFi credentials or RFID card data
+
+## Security Design Choices
+
+### Shared Default TLS Certificate
+
+The repository includes a self-signed EC private key (`SmartEVSE-3/data/key.pem`) and certificate (`SmartEVSE-3/data/cert.pem`) used for the device's built-in HTTPS web server. This is an intentional design choice: every SmartEVSE ships with the same default keypair so that HTTPS works out of the box without requiring a per-device provisioning step.
+
+**Implications:**
+
+- The private key is public knowledge. HTTPS provides encryption in transit but does not authenticate the device — an attacker on the local network could impersonate a SmartEVSE endpoint.
+- All devices share the same certificate, so compromising one does not increase risk to others (there is no unique secret to protect).
+- This is a common tradeoff in embedded devices where there is no certificate authority infrastructure or user-facing provisioning flow.
+
+Users who require stronger TLS authentication should replace the default keypair with a device-specific certificate.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| v3.10.x | Yes |
+| < v3.10 | No |
+
+## Response Timeline
+
+- **Acknowledgment**: Within 48 hours
+- **Initial assessment**: Within 1 week
+- **Fix or mitigation**: Depends on severity, targeting 30 days for critical issues

--- a/docs/REST_API.md
+++ b/docs/REST_API.md
@@ -2,6 +2,12 @@
 
 The REST API can be accessed through any http tool, here as an example CURL will be used.
 
+> **Testing**: REST API input validation is covered by 37 native test cases in
+> [`test_http_api.c`](../SmartEVSE-3/test/native/tests/test_http_api.c). These
+> verify parameter bounds, error responses, and edge cases for all settings
+> endpoints. See the [test specification](../SmartEVSE-3/test/native/test-specification.md)
+> for the full scenario list under the "HTTP API" features.
+
 # GET: /settings
 
 curl -X GET http://ipaddress/settings
@@ -133,6 +139,33 @@ to your curl POST command. -d ''
 <br>&emsp;&emsp;This is used for the EU Capacity rate limiting.
 <br>&emsp;&emsp;Usually you should leave this setting at its default value (600A)
 <br>&emsp;&emsp;since your electricity provider probably does not supports this.
+
+* prio_strategy
+
+&emsp;&emsp;Set the priority strategy for load sharing. Only works when PWR SHARE = Disabled or Master.
+<br>&emsp;&emsp;See [Priority-Based Power Scheduling](priority-scheduling.md) for details.
+<br>&emsp;&emsp;0: Modbus Address
+<br>&emsp;&emsp;1: First Connected
+<br>&emsp;&emsp;2: Last Connected
+```
+    curl -X POST 'http://ipaddress/settings?prio_strategy=1' -d ''
+```
+
+* rotation_interval
+
+&emsp;&emsp;Set the rotation interval in minutes. Only works when PWR SHARE = Disabled or Master.
+<br>&emsp;&emsp;Value must be 0 (disabled) or 30-1440.
+```
+    curl -X POST 'http://ipaddress/settings?rotation_interval=60' -d ''
+```
+
+* idle_timeout
+
+&emsp;&emsp;Set the idle timeout in seconds. Only works when PWR SHARE = Disabled or Master.
+<br>&emsp;&emsp;Value must be 30-300.
+```
+    curl -X POST 'http://ipaddress/settings?idle_timeout=60' -d ''
+```
 
 * cablelock
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,20 +1,80 @@
 
 # How to configure
-* First configure all settings that are shown to you (see below); don't configure your MAINSMET
-* Now you are ready to test/operate your SmartEVSE in its simplest mode, called Normal Mode.
-* If your EV charges at MAX current, everything works as expected, and you don't have a MAINSMET, you are done!
-* If you have a MAINSMET, configure it now; browse through the settings again, since now other options have opened up
-* If you are feeding your SmartEVSE with MAINS or EV data through the REST API or the MQTT API, make sure you have set up these feeds; as soon as you select "API" for the Meters, the data is expected within 11 seconds! You can use the test scripts in the test directory to feed your MQTT server with test data.
-* If you configured MULTIple SmartEVSE's, follow the instructions below
-* Put your SmartEVSE in Solar Mode, and some specific settings for Solar Mode will open up
-* Now your SmartEVSE is ready for use!
 
-# All menu options on the LCD screen:
+## Getting started
+
+1. **Start in Normal mode.** Walk through the settings shown on the LCD. At first, leave MAINS MET unconfigured. Set CONFIG, PWR SHARE, MAX, and the hardware settings (SWITCH, RCMON, RFID, WIFI).
+2. **Test Normal mode.** Verify your EV charges at MAX current. If you don't need Smart/Solar charging and have no mains meter, you are done.
+3. **Configure your mains meter.** Set MODE to Smart or Solar, then configure MAINS MET. New settings will appear in the menu (MAINS, MIN, and more). Browse through them again.
+4. **If using API or MQTT meter feeds**, set up the data feeds before selecting "API" for the meter type. Data is expected within 11 seconds of selecting API. Test scripts are available in the test directory.
+5. **For multiple SmartEVSEs**, see [Power Share setup](#multiple-smartevse-controllers-on-one-mains-supply-power-share) below.
+6. **For Solar mode**, switch to Solar and configure the solar-specific settings (START, STOP, IMPORT) that appear.
+
+## Quick reference: menu visibility
+
+The LCD menu is dynamic. Which settings appear depends on your current MODE and PWR SHARE role. The table below shows all settings **in the order they appear on screen**, with their visibility conditions.
+
+**Legend:** Always = always visible | Smart/Solar = only in Smart or Solar mode | Solar = only in Solar mode | D/M = only when PWR SHARE is Disabled or Master (not shown on Nodes) | conditional = depends on another setting
+
+| # | Setting | Visible when | D/M only | Range | Default |
+|---|---------|-------------|----------|-------|---------|
+| 1 | [MODE](#mode) | Always | | Normal / Smart / Solar | Normal |
+| 2 | [CONFIG](#config) | Always | | Socket / Fixed | Socket |
+| 3 | [LOCK](#lock) | CONFIG = Socket | | Disabled / Solenoid / Motor | Disabled |
+| 4 | [PWR SHARE](#pwr-share) | Always | | Disabled / Master / Node 1-7 | Disabled |
+| 5 | [MAINS MET](#mains-met) | Smart/Solar | D/M | Disabled / Sensorbox / API / ... | Disabled |
+| 6 | [GRID](#grid) | MAINS MET = Sensorbox (with CTs) | D/M | 4Wire / 3Wire | 4Wire |
+| 7 | [SB2 WIFI](#sb2-wifi) | MAINS MET = Sensorbox v2 | D/M | Disabled / Enabled / Portal | Disabled |
+| 8 | [MAINS ADR](#mains-adr) | MAINS MET = Modbus meter | D/M | 10-247 | 10 |
+| 9 | [EV METER](#ev-meter) | Smart/Solar | | Disabled / API / ... | Disabled |
+| 10 | [EV ADR](#ev-adr) | EV METER = Modbus meter | | 10-247 | 12 |
+| 11 | [Custom meter settings](#custom-meter-settings) | Custom meter selected | D/M | (see below) | |
+| 12 | [MAINS](#mains) | MAINS MET configured | D/M | 10-200A | 25A |
+| 13 | [MIN](#min) | MAINS MET configured | D/M | 6-16A | 6A |
+| 14 | [MAX](#max) | Always | | 6-80A | 16A |
+| 15 | [CIRCUIT](#circuit) | Master, or (Disabled + Smart/Solar + EV METER) | | 10-160A | 25A |
+| 16 | [START](#start) | Solar | D/M | 0-48A | 4A |
+| 17 | [STOP](#stop) | Solar | D/M | Disabled / 1-60 min | 10 min |
+| 18 | [IMPORT](#import) | Solar | D/M | 0-48A | 0A |
+| 19 | [CONTACT 2](#contact-2) | Smart/Solar | | (see below) | Always On |
+| 20 | [SWITCH](#switch) | Always | | (see below) | Disabled |
+| 21 | [RCMON](#rcmon) | Always | | Disabled / Enabled | Disabled |
+| 22 | [RFID](#rfid) | Always | | (see below) | Disabled |
+| 23 | [WIFI](#wifi) | Always | | Disabled / SetupWifi / Enabled | Disabled |
+| 24 | [AUTOUPDAT](#autoupdat) | WIFI = Enabled | | Disabled / Enabled | Disabled |
+| 25 | [APP PIN](#app-pin) | WIFI = Enabled | | | |
+| 26 | [APP SERVR](#app-servr) | WIFI = Enabled | | Disabled / Enabled | Disabled |
+| 27 | [MAX TEMP](#max-temp) | Always | | 40-75 C | 65 C |
+| 28 | [CAPACITY](#capacity) | MAINS MET configured | D/M | Disabled / 10-600A | Disabled |
+| 29 | [CAP STOP](#cap-stop) | CAPACITY configured | D/M | Disabled / 1-60 min | Disabled |
+| 30 | [LCD PIN](#lcd-pin) | Always | | 0-9999 | 0 |
+| 31 | [PRIORITY](#priority) | PWR SHARE = Master | D/M | Modbus Adr / First Conn / Last Conn | Modbus Adr |
+| 32 | [ROTATION](#rotation) | PWR SHARE = Master | D/M | 0, 30-1440 min | 0 (off) |
+| 33 | [IDLE TMO](#idle-tmo) | PWR SHARE = Master | D/M | 30-300 s | 60 s |
+
+**"D/M only"** means the setting is hidden when PWR SHARE is set to Node 1-7. Only Disabled and Master see these settings.
+
+### What each role sees
+
+**Standalone (PWR SHARE = Disabled) or Master:**
+All settings in the table above, subject to MODE and meter conditions.
+
+**Node (PWR SHARE = Node 1-7):**
+Only these settings appear: MODE, CONFIG, LOCK, PWR SHARE, EV METER, EV ADR, MAX, CONTACT 2, SWITCH, RCMON, RFID, WIFI (and sub-items), MAX TEMP, LCD PIN. Additionally:
+- SWITCH: the **Grid Relay** option is not selectable on Nodes.
+- CONTACT 2: the **Auto** option is not selectable on Nodes.
+
+---
+
+# LCD menu settings reference
+
+Settings are listed below in the order they appear on the LCD screen.
+
 ## MODE
 By default, you are in normal EVSE mode. You can also choose smart mode or solar mode, but these modes require configuring a [MAINS MET](#mains-met) to function.
 
 - **Normal**: The EV will charge with the current set at [MAX](#max).
-- **Smart**: The EV will charge with a dynamic charge current, depending on [MAINSMET](#mains-met) data, [MAINS](#mains), [MAX](#max) and [MIN](#min) settings.
+- **Smart**: The EV will charge with a dynamic charge current, depending on [MAINS MET](#mains-met) data, [MAINS](#mains), [MAX](#max) and [MIN](#min) settings.
 - **Solar**: The EV will charge using solar power.
 
 ## CONFIG
@@ -24,21 +84,25 @@ Configure SmartEVSE with Type 2 Socket or fixed cable.
 - **Fixed**: The SmartEVSE is connected to a fixed cable, and MAX will determine your maximum charge current.
 
 ## LOCK
-Only appears when [CONFIG](#config) is set to **Socket**.
+> Visible when: CONFIG = Socket
 
 - **Disabled**: No lock is used.
 - **Solenoid**: Dostar, DUOSIDA DSIEC-ELB / ELM, or Ratio lock.
 - **Motor**: Signal wire reversed, DUOSIDA DSIEC-EL or Phoenix Contact.
 
 ## PWR SHARE
-Power Share (formerly LOAD BAL). 2 Upto 8 SmartEVSE’s can be connected via Modbus, and the available power will be shared.
+Power Share (formerly LOAD BAL). Up to 8 SmartEVSEs can be connected via Modbus, and the available power will be shared.
 
 - **Disabled**: Power sharing is not used (single SmartEVSE).
 - **Master**: Set the first SmartEVSE to Master. Only one Master should be set.
-- **Node1-7**: Set the other SmartEVSE’s to Node 1-7.
+- **Node 1-7**: Set the other SmartEVSEs to Node 1-7.
+
+Changing this setting controls which other settings are visible. See [quick reference table](#quick-reference-menu-visibility) and [Power Share setup](#multiple-smartevse-controllers-on-one-mains-supply-power-share).
 
 ## MAINS MET
-Only appears if [MODE](#mode) is **Smart** or **Solar**. Set the type of MAINS kWh Meter.
+> Visible when: MODE = Smart or Solar, AND PWR SHARE = Disabled or Master
+
+Set the type of MAINS kWh Meter.
 
 - **Disabled**: No MAINS meter connected (only Normal mode possible).
 - **Sensorbox**: The Sensorbox sends measurement data to the SmartEVSE.
@@ -46,57 +110,123 @@ Only appears if [MODE](#mode) is **Smart** or **Solar**. Set the type of MAINS k
 - **Phoenix C** / **Finder** / **...** / **Custom**: A Modbus kWh meter is used.
 - **HmWzrd P1**: HomeWizard P1 meter (wifi based connection to the smart meter's P1 port).
 
-**Note**:  
-- Eastron1P is for single-phase Eastron meters.  
-- Eastron3P is for Eastron three-phase meters.  
+**Note**:
+- Eastron1P is for single-phase Eastron meters.
+- Eastron3P is for Eastron three-phase meters.
 - InvEastron is for Eastron three-phase meters fed from below (inverted).
 
-If MAINS MET is not **Disabled** and not **API**, these settings appear:
+Configuring a mains meter unlocks additional settings: GRID, SB2 WIFI, MAINS ADR, MAINS, MIN, CAPACITY, and (in Solar mode) START, STOP, IMPORT.
 
-- **MAINSADR**: Set the Modbus address for the kWh meter.
-- **GRID**: 3 or 4 wire (only appears when Sensorbox with CT’s is used).
-  - **4Wire**: Star connection with 3 phase wires and neutral.
-  - **3Wire**: Delta connection with 3 phase wires without neutral.
+## GRID
+> Visible when: MAINS MET = Sensorbox with CT's, AND PWR SHARE = Disabled or Master
+
+- **4Wire**: Star connection with 3 phase wires and neutral.
+- **3Wire**: Delta connection with 3 phase wires without neutral.
+
+## SB2 WIFI
+> Visible when: MAINS MET = Sensorbox v2, AND PWR SHARE = Disabled or Master
+
+Connect Sensorbox-2 to WiFi.
+
+- **Disabled**: Sensorbox-2 WiFi disabled.
+- **Enabled**: Connect Sensorbox-2 via WiFi.
+- **Portal**: WiFi configuration portal.
+
+## MAINS ADR
+> Visible when: MAINS MET = Modbus meter (not Disabled, API, Sensorbox, or HmWzrd P1), AND PWR SHARE = Disabled or Master
+
+Set the Modbus address for the mains kWh meter: 10-247.
 
 ## EV METER
-Set Type of EV kWh Meter (measures power and charged energy)
+> Visible when: MODE = Smart or Solar (any PWR SHARE role, including Nodes)
+
+Set the type of EV kWh Meter (measures power and charged energy).
 
 - **Disabled**: No EV meter connected.
 - **API**: EV meter data is fed through the REST API or MQTT API.
 - **Phoenix C** / **Finder** / **...** / **Custom**: A Modbus kWh meter is used.
 
-**Note**:  
-- Eastron1P is for single-phase Eastron meters.  
-- Eastron3P is for Eastron three-phase meters.  
-- InvEastron is for Eastron’s three-phase meter fed from below (inverted).
+**Note**:
+- Eastron1P is for single-phase Eastron meters.
+- Eastron3P is for Eastron three-phase meters.
+- InvEastron is for Eastron three-phase meters fed from below (inverted).
 
-If EV METER is not **Disabled** and not **API**, this setting appears:
+## EV ADR
+> Visible when: EV METER = Modbus meter (not Disabled or API)
 
-- **EV ADR**: Set the Modbus address for the EV Meter.
+Set the Modbus address for the EV Meter: 10-247.
+
+## Custom meter settings
+> Visible when: MAINS MET or EV METER = Custom, AND PWR SHARE = Disabled or Master
+
+These settings configure a custom Modbus energy meter. All share the same configuration (one custom meter definition is used for both mains and EV if both are set to Custom).
+
+| Setting | Description | Range |
+|---------|-------------|-------|
+| BYTE ORD | Byte order | 0-3 |
+| DATA TYPE | Modbus data type | 0-4 |
+| FUNCTION | Modbus function (3=holding, 4=input) | 3-4 |
+| VOL REGI | Register for Voltage (V) | 0-65530 |
+| VOL DIVI | Divisor for Voltage | 0-7 |
+| CUR REGI | Register for Current (A) | 0-65530 |
+| CUR DIVI | Divisor for Current | 0-7 |
+| POW REGI | Register for Power (W) | 0-65534 |
+| POW DIVI | Divisor for Power | 0-7 |
+| ENE REGI | Register for Energy (kWh) | 0-65534 |
+| ENE DIVI | Divisor for Energy | 0-7 |
 
 ## MAINS
-Only appears when a [MAINS MET](#mains-met) is configured. Set max mains current (10-200A) per phase.
+> Visible when: MAINS MET configured (not Disabled), AND PWR SHARE = Disabled or Master
+
+Set max mains current: 10-200A per phase. This is the hard limit of your mains connection.
 
 ## MIN
-Only appears when a [MAINS MET](#mains-met) is configured. Set the min charge current for the EV (6-16A) per phase.
+> Visible when: MAINS MET configured (not Disabled), AND PWR SHARE = Disabled or Master
+
+Set the minimum charge current the EV will accept: 6-16A per phase.
 
 ## MAX
-Set the MAX charge current for the EV: (10-80A) per phase. If [CONFIG](#config) is set to **Fixed**, configure MAX to be lower than or equal to the maximum current that your fixed cable can carry.
+Set the MAX charge current for the EV: 6-80A per phase. Always visible regardless of mode or role.
+
+If [CONFIG](#config) is set to **Fixed**, configure MAX to be lower than or equal to the maximum current that your fixed cable can carry.
 
 ## CIRCUIT
-Only appears when an [EV METER](#ev-meter) is configured, in **Smart** or **Solar** mode. Set the max current the EVSE circuit can handle (power sharing): 10-200A.  
+> Visible when: PWR SHARE = Master, OR (PWR SHARE = Disabled AND MODE = Smart/Solar AND EV METER configured)
+
+Set the max current of the EVSE circuit: 10-160A per phase. When power sharing, this is the total current that will be split between connected and charging EVs.
 
 ## START
-Only shown when [MODE](#mode) is set to **Solar** and [PWR SHARE](#pwr-share) is set to **Disabled** or **Master**. Set the current at which the EV should start solar charging: -0 to -48A (sum of all phases).
+> Visible when: MODE = Solar, AND PWR SHARE = Disabled or Master
 
-## STOP  
-Only shown when [MODE](#mode) is set to **Solar** and [PWR SHARE](#pwr-share) is set to **Disabled** or **Master**. Stop charging when there is not enough solar power available. 1-60 minutes or
-  - **Disabled**: Never stop charging.  
- 
+Set the surplus energy current at which the EV should start solar charging: 0-48A (sum of all phases).
+
+## STOP
+> Visible when: MODE = Solar, AND PWR SHARE = Disabled or Master
+
+Stop charging when there is not enough solar power available.
+
+- **Disabled**: Never stop charging.
+- **1-60 min**: Stop after this many minutes below the threshold.
+
 ## IMPORT
-Only shown when [MODE](#mode) is set to **Solar** and [PWR SHARE](#pwr-share) is set to **Disabled** or **Master**. Allow additional grid power when solar charging: 0-20A (sum of all phases). Use this when there is not enough solar power but you want to use as much solar power as possible.
+> Visible when: MODE = Solar, AND PWR SHARE = Disabled or Master
+
+Allow additional grid power when solar charging: 0-48A (sum of all phases). Use this when there is not enough solar power but you want to use as much solar power as possible.
 
 **Important Note**: START and IMPORT are summed over all phases, and MIN is per phase!
+
+## CONTACT 2
+> Visible when: MODE = Smart or Solar
+
+Use a second contactor (C2) to switch phases L2 and L3.
+
+- **Not present**: The second contactor is not present, and SmartEVSE assumes 3-phase charging.
+- **Always Off**: C2 is always off, single-phase charging. WE RECOMMEND THIS SETTING IF YOU ARE SINGLE PHASE CHARGING IN SOLAR MODE, EVEN IF YOU DONT HAVE A second contactor INSTALLED!
+- **Always On**: C2 is always on, three-phase charging (default).
+- **Solar Off**: C2 is always on except in Solar Mode, where it is always off.
+- **Auto**: SmartEVSE starts charging at 3-phase, but in Solar Mode, it will switch off C2 when there is not enough current for 3 phases, continuing on 1 phase; if there is enough current it will switch on C2, continuing on 3 phases. In Smart mode we will charge 3P, since we assume you are switching to Smart mode because not enough sun is available for Solar mode. **Note: Auto is not available on Nodes (PWR SHARE = Node 1-7).**
+
+**Important**: Wire your C2 contactor according to the schematics in the [Hardware installation](installation.md).
 
 ## SWITCH
 Set the Function of an External Switch (Pin SW or Connector P2).
@@ -106,7 +236,7 @@ Set the Function of an External Switch (Pin SW or Connector P2).
 - **Access S**: A toggle switch is used to enable/disable access to the charging station.
 - **Sma-Sol B**: A momentary push button is used to switch between Smart and Solar modes.
 - **Sma-Sol S**: A toggle switch is used to switch between Smart and Solar modes.
-- **Grid Relay**: A relay from your energy provider is connected; when the relay is open, power usage is limited to 4.2kW (Energy Industry Act, par 14a).
+- **Grid Relay**: A relay from your energy provider is connected; when the relay is open, power usage is limited to 4.2kW (Energy Industry Act, par 14a). **Note: Grid Relay is not available on Nodes (PWR SHARE = Node 1-7).**
 - **Custom B**: A momentary push button can be used for external integrations.
 - **Custom S**: A toggle switch can be used for external integrations.
 
@@ -129,22 +259,22 @@ Use an RFID Card Reader to Enable/Disable Access to the EVSE. A maximum of 100 R
 - **Rmt/OCPP**: Authorize remotely over OCPP and bypass the SmartEVSE's local RFID storage.
 
 ## WIFI
-Enable Wifi connection to your network.
+Enable WiFi connection to your network.
 
-- **Disabled**: Wifi connection is disabled.
-- **SetupWifi** 
+- **Disabled**: WiFi connection is disabled.
+- **SetupWifi**
   - v3.9.0 or newer:
-  The SmartEVSE presents itself as a Wifi Acces Point with SSID "SmartEVSE-config"; the password is displayed at the top line of your LCD display. Connect with your phone to that access point, go to [http://192.168.4.1/](http://192.168.4.1/) and configure your Wifi SSID and password.
+  The SmartEVSE presents itself as a WiFi Access Point with SSID "SmartEVSE-config"; the password is displayed at the top line of your LCD display. Connect with your phone to that access point, go to [http://192.168.4.1/](http://192.168.4.1/) and configure your WiFi SSID and password.
   - v3.6.4 until v3.8.x:
-    - Connect your smartphone to the wifi network you want your SmartEVSE connected to.
-Note: If you have a multi AP setup, with the same SSID, you need to be connected to the desired AP, as the configuration is based on the BSSID, so it will choos the specific AP your phone is connected to.
+    - Connect your smartphone to the WiFi network you want your SmartEVSE connected to.
+Note: If you have a multi AP setup, with the same SSID, you need to be connected to the desired AP, as the configuration is based on the BSSID, so it will choose the specific AP your phone is connected to.
     - Download and run the ESPTouch app from your favorite app store [Android](https://play.google.com/store/apps/details?id=com.fyent.esptouch.android&hl=en_US:) (please ignore the strange Author name) or [Apple](https://apps.apple.com/us/app/espressif-esptouch/id1071176700) or  [Github](https://github.com/EspressifApp/EsptouchForAndroid) (for source code).
     - Choose EspTouch V2.
-    - Fill in the key (password) of the wifi network.
+    - Fill in the key (password) of the WiFi network.
     - Fill in **1** in device count for provisioning.
-    - On the SmartEVSE LCD screen, select **Wifi**, select **SetupWifi**
+    - On the SmartEVSE LCD screen, select **WiFi**, select **SetupWifi**
     - Press the middle button to start the configuration procedure.
-    - Once pressed, the bottom line shows you a 16 character key, first 8 are 01234567. note that from this point on, you have 120s TO FINISH this procedure!
+    - Once pressed, the bottom line shows you a 16 character key, first 8 are 01234567. Note that from this point on, you have 120s TO FINISH this procedure!
     - Fill in that key in the ESPTouch app, in the AES Key field
     - Leave Custom Data empty
     - Press **Confirm**, within 30 seconds the app will confirm a MAC address and an IP address.
@@ -159,23 +289,27 @@ Note: If you have a multi AP setup, with the same SSID, you need to be connected
       - 8 bits
       - no parity
       - 1 stopbit
-    - on the SmartEVSE LCD screen, select "Wifi", select "SetupWifi"
+    - on the SmartEVSE LCD screen, select "WiFi", select "SetupWifi"
     - press the middle button to start the configuration procedure
-    - on your terminal window you should see a request to enter your WiFi access point SSID and password. 
+    - on your terminal window you should see a request to enter your WiFi access point SSID and password.
     - the controller should now connect to WiFi.
   - v3.6.3 or older:
-  The SmartEVSE presents itself as a Wifi Acces Point with SSID "smartevse-xxxx". Connect with your phone to that access point, go to [http://192.168.4.1/](http://192.168.4.1/) and configure your Wifi SSID and key (password).
-- **Enabled**: Connect to your network via Wifi.
+  The SmartEVSE presents itself as a WiFi Access Point with SSID "smartevse-xxxx". Connect with your phone to that access point, go to [http://192.168.4.1/](http://192.168.4.1/) and configure your WiFi SSID and key (password).
+- **Enabled**: Connect to your network via WiFi.
 
 ## AUTOUPDAT
-Only appears when [WIFI](#wifi) is **Enabled**. Automatic update of the SmartEVSE firmware.
+> Visible when: WIFI = Enabled
+
+Automatic update of the SmartEVSE firmware.
 
 - **Disabled**: No automatic update.
-- **Enabled**: Checks daily for a new stable firmware version and installs it when no EV is connected.  
+- **Enabled**: Checks daily for a new stable firmware version and installs it when no EV is connected.
   **Note**: This will not work if your version is not in the format `vx.y.z` (e.g., v3.6.1). Locally compiled versions or RCx versions will not auto-update.
 
 ## APP PIN
-Only appears when [WIFI](#wifi) is **Enabled**. Generate a 6-digit pairing PIN for connecting the SmartEVSE mobile app.
+> Visible when: WIFI = Enabled
+
+Generate a 6-digit pairing PIN for connecting the SmartEVSE mobile app.
 
 - Press the middle button to generate a new PIN.
 - The PIN is displayed on the LCD screen and is valid for 2 minutes.
@@ -183,7 +317,9 @@ Only appears when [WIFI](#wifi) is **Enabled**. Generate a 6-digit pairing PIN f
 - The PIN is automatically cleared when you exit the menu or after the timeout expires.
 
 ## APP SERVR
-Only appears when [WIFI](#wifi) is **Enabled**. Enable or disable the connection to the SmartEVSE cloud server for mobile app integration.
+> Visible when: WIFI = Enabled
+
+Enable or disable the connection to the SmartEVSE cloud server for mobile app integration.
 
 - **Disabled**: No connection to the SmartEVSE server.
 - **Enabled**: Connect to `mqtt.smartevse.nl` for mobile app communication.
@@ -192,38 +328,102 @@ When enabled, the top row shows the current connection status:
 - **Connected to server**: Successfully connected to the SmartEVSE server.
 - **No server connection**: Not connected to the server.
 
-This feature uses a unique per-device key stored in the controller. If you somehow erased the controller completely this data will be lost, and the controller will not be able to connect to the server. 
+This feature uses a unique per-device key stored in the controller. If you somehow erased the controller completely this data will be lost, and the controller will not be able to connect to the server.
 
 ## MAX TEMP
-Maximum allowed temperature for your SmartEVSE: 40-75°C (default 65°C).  
-Charging will stop once the internal temperature reaches this threshold and resume once it drops to 55°C.
+Maximum allowed temperature for your SmartEVSE: 40-75 C (default 65 C).
+Charging will stop once the internal temperature reaches this threshold and resume once it drops to 55 C.
 
 ## CAPACITY
-Only appears when a [MAINSMET](#mains-met) is configured. Maximum allowed mains current summed over all phases: 10-600A. Used for the EU Capacity rate limiting.
+> Visible when: MAINS MET configured (not Disabled), AND PWR SHARE = Disabled or Master
+
+Maximum allowed mains current summed over all phases: 10-600A. Used for [EU Capacity Rate Limiting](#eu-capacity-rate-limiting).
+
+- **Disabled** (0): Capacity rate limiting not used.
+- **10-600A**: Limit the sum of all mains phase currents to this value.
 
 ## CAP STOP
-Only appears when [CAPACITY](#capacity) is configured. Timer in minutes. If CAPACITY is exceeded, charging will not immediately stop but will wait until the timer expires.  
-- If set to **Disabled**, charging stops immediately when CAPACITY is exceeded.
+> Visible when: CAPACITY is configured (not Disabled)
+
+Timer in minutes. If CAPACITY is exceeded, charging will not immediately stop but will wait until the timer expires.
+
+- **Disabled**: Charging stops immediately when CAPACITY is exceeded.
+- **1-60 min**: Wait this many minutes before stopping.
 
 ## LCD PIN
 Pin code so that you can use the buttons on the LCD menu on the web-interface.
 Left button increases the digit by one, Right button goes to next digit, Middle button ends entry.
 
-## CONTACT2
-Use a second contactor (C2) to switch phases L2 and L3. 
+## PRIORITY
+> Visible when: PWR SHARE = Master
 
-- **Not present**: The second contactor is not present, and SmartEVSE assumes 3-phase charging.
-- **Always Off**: C2 is always off, single-phase charging. WE RECOMMEND THIS SETTING IF YOU ARE SINGLE PHASE CHARGING IN SOLAR MODE, EVEN IF YOU DONT HAVE A second contactor INSTALLED!
-- **Always On**: C2 is always on, three-phase charging (default).
-- **Solar Off**: C2 is always on except in Solar Mode, where it is always off.
-- **Auto**: (only available when POWER SHARE Disabled or Master): SmartEVSE starts charging at 3-phase, but in Solar Mode, it will switch off C2 when there is not enough current for 3 phases, continuing on 1 phase; if there is enough current it will switch on C2, continuing on 3 phases. In Smart mode we will charge 3P, since we assume you are switching to Smart mode because not enough sun is available for Solar mode.
+Set the priority strategy for load sharing when there is not enough power for all connected EVSEs. See [Priority-Based Power Scheduling](priority-scheduling.md) for full details.
 
-**Important**: Wire your C2 contactor according to the schematics in the [Hardware installation](installation.md).
+- **Modbus Adr**: Lower Modbus address = higher priority (Master first, then Node 1, 2, ...).
+- **First Conn**: The car that plugged in first gets priority.
+- **Last Conn**: The most recently plugged-in car gets priority.
+
+## ROTATION
+> Visible when: PWR SHARE = Master
+
+How often to rotate which EVSE is actively charging. See [Priority-Based Power Scheduling](priority-scheduling.md) for full details.
+
+- **0**: Disabled — no rotation. The highest-priority EVSE charges until done.
+- **30–1440**: Rotate every N minutes.
+
+## IDLE TMO
+> Visible when: PWR SHARE = Master
+
+How many seconds to wait before deciding an EVSE is idle and moving to the next one. Also serves as anti-flap protection. See [Priority-Based Power Scheduling](priority-scheduling.md) for full details.
+
+- **30–300**: Seconds (default 60).
+
+---
+
+# Setup guides by role
+
+## Single SmartEVSE (standalone)
+
+1. Set **PWR SHARE** = Disabled
+2. Set **CONFIG** (Socket or Fixed) and **LOCK** if using a socket
+3. Set **MAX** to the maximum current your cable/installation supports
+4. Set **WIFI**, **SWITCH**, **RCMON**, **RFID** as needed for your hardware
+5. If you only need Normal mode, you are done
+6. For Smart/Solar: set **MODE**, then configure **MAINS MET** and the settings that appear (MAINS, MIN, etc.)
+7. For Solar mode: configure **START**, **STOP**, **IMPORT**
+8. For single-phase charging in Solar mode: set **CONTACT 2** = Always Off
+
+## Master setup (Power Share)
+
+1. Set **PWR SHARE** = Master
+2. Set **MODE** to Smart (or Solar) with a Sensorbox or configured kWh meter
+3. Configure **MAINS MET** and **MAINS** (maximum current of the mains connection per phase)
+4. Set **CIRCUIT** to the maximum current of the EVSE circuit per phase (shared between EVs)
+5. Set **MAX** for the EV connected to this SmartEVSE
+6. Set **MIN** to the lowest allowable charging current for all connected EVs
+7. Configure remaining hardware settings (WIFI, SWITCH, RCMON, RFID, etc.)
+8. Optionally configure **PRIORITY**, **ROTATION**, and **IDLE TMO** for [priority scheduling](priority-scheduling.md) — these control what happens when there isn't enough power for all EVSEs
+
+## Node setup (Power Share)
+
+Nodes have a reduced menu. Most metering and balancing settings are managed by the Master.
+
+1. Set **PWR SHARE** = Node 1-7 (unique number for each Node)
+2. Set **MAX** for the EV connected to this SmartEVSE
+3. Optionally configure **EV METER** if this Node has its own EV meter
+4. Configure hardware settings (CONFIG, LOCK, SWITCH, RCMON, RFID, WIFI, etc.)
+
+**Note**: The following restrictions apply to Nodes:
+- SWITCH: the Grid Relay option is not available
+- CONTACT 2: the Auto option is not available
+- Settings managed by the Master (MAINS MET, MAINS, MIN, CIRCUIT, START, STOP, IMPORT, CAPACITY, custom meter configuration) do not appear in the Node menu
+
+---
 
 # SINGLE PHASE CHARGING
 
 SmartEVSE calculates with currents per phase; a problem arises in Solar mode, because there Isum (the sum of the currents of all phases) has to be guarded; to calculate with it per phase you have to know the number of phases you are charging.
-We try to detect the number of phases you are charging with, with the help of the settings of the second contator C2 and the EVMeter, if present.
+We try to detect the number of phases you are charging with, with the help of the settings of the second contactor C2 and the EVMeter, if present.
 This detection can fail easily; not always an EVMeter is present, and even if there is, an EV could determine to start charging at one phase and later on add more phases (Teslas are known to do this); an EV could even decide during the charging process to stop charging on certain phases.
 We could introduce a setting "1phase/3phase" charging, but this setting would be EV dependent if you are on a 3 phase grid; so you would have to change the setting every time another EV connects to your SmartEVSE.
 
@@ -233,6 +433,18 @@ Currently the most reliable way to get the correct behaviour at Solar mode is:
 - if you are on a 1 phase grid, set CONTACT2 to "Always Off" since you will always be charging single phase
 
 If you are at Smart mode you just set CONTACT2 to the appropriate setting as documented above.
+
+# Multiple SmartEVSE controllers on one mains supply (Power Share)
+Up to eight SmartEVSE modules can share one mains supply.
+
+## Hardware connections
+- Connect the A, B and GND connections from the Master to the Node(s).
+- So A connects to A, B goes to B etc.
+- If you are using Smart/Solar mode, you should connect the A, B, +12V and GND wires from the sensorbox to the same screw terminals of the SmartEVSE! Make sure that the +12V wire from the sensorbox is connected to only -one- SmartEVSE.
+
+## Software configuration
+- Set one SmartEVSE PWR SHARE setting to MASTER, and the others to NODE 1-7. Make sure there is only one Master, and the Node numbers are unique.
+- See [Master setup](#master-setup-power-share) and [Node setup](#node-setup-power-share) above for step-by-step instructions.
 
 # OCPP (you want your company to pay for your electricity charges, or you want to exploit your SmartEVSE as a public charger)
 To charge a company or a user for your electricity cost, you need a Backend Provider (BP). The BP will monitor your charger usage and will bill the appropriate user and/or company, and will pay you your part.
@@ -283,19 +495,24 @@ Valid topics you can publish to are:
                Example: "112233445566" (6 bytes) or "11223344556677" (7 bytes)
                This will simulate an RFID card swipe and start/stop a charging session using all existing RFID checks
                (whitelist verification, OCPP authorization, etc.)
+/Set/PrioStrategy       0=Modbus Address, 1=First Connected, 2=Last Connected (Master only)
+/Set/RotationInterval   0=disabled, 30-1440 minutes (Master only)
+/Set/IdleTimeout        30-300 seconds (Master only)
 ```
+
+For details on the scheduling topics, see [Priority-Based Power Scheduling](priority-scheduling.md).
 Your mains kWh meter data can be fed with:
 ```
 mosquitto_pub  -h ip-of-mosquitto-server -u username -P password -t 'SmartEVSE-xxxxx/Set/MainsMeter' -m L1:L2:L3
 ```
-...where L1 - L3 are the currents in deci-Ampères. So 100 means 10.0A importing, -5 means 0.5A exporting.
-...These should be fed at least ervery 10 seconds.
+...where L1 - L3 are the currents in deci-Amperes. So 100 means 10.0A importing, -5 means 0.5A exporting.
+...These should be fed at least every 10 seconds.
 
 Your EV kWh meter data can be fed with:
 ```
 mosquitto_pub  -h ip-of-mosquitto-server -u username -P password -t 'SmartEVSE-xxxxx/Set/EVMeter' -m L1:L2:L3:P:E
 ```
-...where L1 - L3 are the currents in deci-Ampères. So 100 means 10.0A.
+...where L1 - L3 are the currents in deci-Amperes. So 100 means 10.0A.
 ...where P is the Power in W,
 ...where E is the Energy in Wh.
 
@@ -312,27 +529,6 @@ You can find test scripts in the [test directory](https://github.com/SmartEVSE/S
 
 The `/Set/CurrentMaxSumMains` topic can be used to set the [CAPACITY](#capacity) setting.
 
-# Multiple SmartEVSE controllers on one mains supply (Power Share)
-Up to eight SmartEVSE modules can share one mains supply.
-  - Hardware connections
-    - Connect the A, B and GND connections from the Master to the Node(s).
-    - So A connects to A, B goes to B etc.
-    - If you are using Smart/Solar mode, you should connect the A, B , +12V and GND wires from the sensorbox to the same screw terminals of the SmartEVSE! Make sure that the +12V wire from the sensorbox is connected to only -one– SmartEVSE.
-
-  - Software configuration
-    - Set one SmartEVSE PWR SHARE setting to MASTER, and the others to NODE 1-7. Make sure there is only one Master, and the Node numbers are unique.
-    - On the Master configure the following:
-      - MODE	  Set this to Smart if a Sensorbox (or configured kWh meter) is used to measure the current draw on the mains supply.
-      It will then dynamically vary the charge current for all connected EV’s.  If you are using a dedicated mains supply for the EV’s you can leave this set to Normal.
-      - MAINS Set to the maximum current of the MAINS connection (per phase).
-      If the sensorbox or other MainsMeter device measures a higher current than this value on one of the phases, it will immediately reduce the current to the EVSE’s
-      - CIRCUIT Set this to the maximum current of the EVSE circuit (per phase).
-      This will be split between the connected and charging EV’s.
-      - MAX 		 Set the maximum charging current for the EV connected to -this- SmartEVSE (per phase).
-      - MIN		 Set to the lowest allowable charging current for all connected EV’s.
-    - On the Nodes configure the following:
-      - MAX 		 Set the maximum charging current for the EV connected to -this- SmartEVSE (per phase).
-
 # Home Battery Integration
 In a normal EVSE setup, a sensorbox is used to read the P1 information to deduce if there is sufficient solar energy available. This however can give unwanted results when also using a home battery as this will result in one battery charging the other one.
 
@@ -344,7 +540,7 @@ The EVSE will use the battery current to neutralize the impact of a home battery
 
 **Regular updates from the consumer are required to keep this working as values cannot be older than 11 seconds.**
 
-**The battery currents are ONLY taken into account in Solar mode!!
+**The battery currents are ONLY taken into account in Solar mode!**
 
 ### Example
 * Home battery is charging at 2300W -> 10A
@@ -377,18 +573,13 @@ If you cannot (or do not want to) use MQTT to integrate your SmartEVSE with Home
 
 It's a lot of work, but you can have everything exactly your way. See examples in the integrations directory of our GitHub repository.
 
-
-
 # EU Capacity Rate Limiting
 
 In line with a EU directive, electricity providers can implement a "capacity rate" for consumers, encouraging more balanced energy consumption. This approach aims to smooth out usage patterns and reduce peak demand.
 
 For further details, please refer to [serkri#215](https://github.com/serkri/SmartEVSE-3/issues/215).
 
-
-
 * The menu item "Capacity" can be set from 10-600A. (sum of all phases)
 * This setting applies only in Smart or Solar mode.
 * Beyond existing limits (Mains, MaxCircuit), the charging current will be controlled to ensure that the total of all Mains phase currents does not exceed the Capacity setting.
 * If you are unfamiliar with this setting or do not fall under the applicable regulations, it is advisable to keep the setting at its default setting. (disabled)
-


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — project instructions for AI agents and contributors (architecture, safety rules, SbE workflow, multi-agent protocol)
- **CODING_STANDARDS.md** — naming conventions, memory rules, C11 standard, zero-warnings policy
- **CONTRIBUTING.md** — SbE specification-first workflow, branch naming, bug reporting template
- **SECURITY.md** — private vulnerability disclosure process
- **docs/configuration.md** — restructured to match actual LCD menu order; adds quick-reference table and role guides for Standalone / Master / Node
- **docs/REST_API.md** — documents `/automated` and `/currents` endpoints
- **README.md** — testing metrics, documentation links

## Test plan
- [ ] All documentation links resolve correctly
- [ ] Configuration guide matches current firmware LCD menu order

🤖 Generated with [Claude Code](https://claude.com/claude-code)