### PR TITLE
docs: switch traceability report link from HTML to Markdown

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,8 @@ jobs:
         run: |
           python scripts/extract_traceability.py \
             --html traceability-report.html \
-            --markdown test-specification.md
+            --markdown test-specification.md \
+            --markdown-report traceability-report.md
       - name: Validate state transitions
         working-directory: SmartEVSE-3/test/native
         run: python scripts/validate_transitions.py
@@ -158,13 +159,14 @@ jobs:
           name: traceability-reports
           path: |
             SmartEVSE-3/test/native/traceability-report.html
+            SmartEVSE-3/test/native/traceability-report.md
             SmartEVSE-3/test/native/test-specification.md
       - name: Commit updated test specification
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add SmartEVSE-3/test/native/test-specification.md SmartEVSE-3/test/native/traceability-report.html
+          git add SmartEVSE-3/test/native/test-specification.md SmartEVSE-3/test/native/traceability-report.md SmartEVSE-3/test/native/traceability-report.html
           if git diff --cached --quiet; then
             echo "Reports are already up to date"
           else

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ CI pipeline generates two reports on every build:
 - **[Test Specification](SmartEVSE-3/test/native/test-specification.md)** — Markdown
   document listing all scenarios grouped by feature, with requirement IDs and
   Given/When/Then steps. Auto-regenerated and committed on every merge to master.
-- **[Traceability Report](SmartEVSE-3/test/native/traceability-report.html)** — Interactive HTML matrix
-  mapping requirements to test functions. Auto-regenerated and committed on every
-  merge to master. Also attached to every GitHub release.
+- **[Traceability Report](SmartEVSE-3/test/native/traceability-report.md)** — Requirement-to-test
+  matrix showing which tests cover each requirement, grouped by feature. Auto-regenerated
+  and committed on every merge to master. Also attached to every GitHub release.
 
 Additional CI artifacts:
 
@@ -117,7 +117,7 @@ To generate the specification and traceability reports locally:
 
 ```bash
 cd SmartEVSE-3/test/native
-python3 scripts/extract_traceability.py --html traceability-report.html --markdown test-specification.md
+python3 scripts/extract_traceability.py --html traceability-report.html --markdown test-specification.md --markdown-report traceability-report.md
 ```
 
 # SmartEVSE App


### PR DESCRIPTION
## Summary

- Replaces the `traceability-report.html` link in README with `traceability-report.md`, which renders natively on GitHub without needing to download or host the file
- CI now generates `traceability-report.md` via `--markdown-report` flag on every build and auto-commits it alongside `test-specification.md`
- `traceability-report.md` added to the `traceability-reports` CI artifact upload
- Local generation command in README updated to include `--markdown-report`

## Test plan

- [ ] CI traceability job generates `traceability-report.md` and includes it in artifacts
- [ ] On a master push, CI auto-commits updated `traceability-report.md`
- [ ] README link to `traceability-report.md` resolves correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)