### PR TITLE
feat: extract pure C OCPP logic module (Plan 03, Issue #28)

### DIFF
--- a/SmartEVSE-3/src/evse_ctx.h
+++ b/SmartEVSE-3/src/evse_ctx.h
@@ -93,6 +93,7 @@ extern "C" {
 #define PILOT_12V   12
 #define PILOT_9V     9
 #define PILOT_6V     6
+#define PILOT_3V     3
 #define PILOT_DIODE  1
 #define PILOT_SHORT  255
 #define PILOT_NOK    0

--- a/SmartEVSE-3/src/ocpp_logic.c
+++ b/SmartEVSE-3/src/ocpp_logic.c
@@ -1,0 +1,178 @@
+/*
+ * ocpp_logic.c - Pure C OCPP decision logic
+ *
+ * Extracted from esp32.cpp OCPP lambdas. All functions are pure: they take
+ * inputs and return decisions without side effects, making them testable
+ * natively with gcc on any host.
+ */
+
+#include "ocpp_logic.h"
+#include "evse_ctx.h"
+#include <string.h>
+#include <stdio.h>
+
+/* ---- Auth path selection ---- */
+
+ocpp_auth_path_t ocpp_select_auth_path(uint8_t rfid_reader) {
+    /* RFIDReader=0 (disabled) or RFIDReader=6 (Rmt/OCPP): OCPP controls Access_bit */
+    if (rfid_reader == 0 || rfid_reader == 6) {
+        return OCPP_AUTH_PATH_OCPP_CONTROLLED;
+    }
+    /* RFIDReader=1..5: built-in RFID store controls charging, OCPP just reports */
+    return OCPP_AUTH_PATH_BUILTIN_RFID;
+}
+
+/* ---- Connector state ---- */
+
+bool ocpp_is_connector_plugged(uint8_t cp_voltage) {
+    /* Matches esp32.cpp: PILOT_3V..PILOT_9V means connector is plugged */
+    return cp_voltage >= PILOT_3V && cp_voltage <= PILOT_9V;
+}
+
+bool ocpp_is_ev_ready(uint8_t cp_voltage) {
+    /* PILOT_3V..PILOT_6V = State C (EV requesting charge) */
+    return cp_voltage >= PILOT_3V && cp_voltage <= PILOT_6V;
+}
+
+/* ---- Access decision ---- */
+
+bool ocpp_should_set_access(bool permits_charge, bool prev_permits_charge) {
+    /*
+     * Set Access_bit only on rising edge: OCPP just started permitting charge.
+     * From esp32.cpp: if (!OcppTrackPermitsCharge && ocppPermitsCharge())
+     * This ensures we set Access_bit only once per OCPP transaction, so other
+     * modules can override it without OCPP re-setting it.
+     */
+    return !prev_permits_charge && permits_charge;
+}
+
+bool ocpp_should_clear_access(bool permits_charge, uint8_t access_status) {
+    /*
+     * Clear Access_bit when OCPP revokes permission and Access is currently ON.
+     * From esp32.cpp: if (AccessStatus == ON && !ocppPermitsCharge())
+     */
+    return access_status == 1 && !permits_charge;  /* 1 = ON */
+}
+
+/* ---- RFID hex formatting ---- */
+
+void ocpp_format_rfid_hex(const uint8_t *rfid, size_t rfid_len,
+                          char *out, size_t out_size) {
+    if (!rfid || !out || out_size == 0 || rfid_len == 0) {
+        if (out && out_size > 0) out[0] = '\0';
+        return;
+    }
+
+    size_t start = 0;
+    size_t count = rfid_len;
+
+    /*
+     * Old reader format: rfid[0]==0x01 means the 6-byte UID starts at rfid[1].
+     * New reader format: rfid[0]!=0x01 means the 7-byte UID starts at rfid[0].
+     * From esp32.cpp ocppLoop():
+     *   if (RFID[0] == 0x01) snprintf(buf, ..., RFID[1]..RFID[6])
+     *   else                 snprintf(buf, ..., RFID[0]..RFID[6])
+     */
+    if (rfid_len >= 7 && rfid[0] == 0x01) {
+        start = 1;
+        count = 6;
+    }
+
+    out[0] = '\0';
+    for (size_t i = start; i < start + count && i < rfid_len; i++) {
+        size_t pos = (i - start) * 2;
+        if (pos + 2 >= out_size) break;
+        snprintf(out + pos, 3, "%02X", rfid[i]);
+    }
+}
+
+/* ---- Load balancing exclusivity ---- */
+
+ocpp_lb_status_t ocpp_check_lb_exclusivity(uint8_t load_bl, bool ocpp_mode,
+                                           bool was_standalone) {
+    if (!ocpp_mode) {
+        return OCPP_LB_OK;
+    }
+
+    if (load_bl != 0) {
+        /* LoadBl is non-zero while OCPP is active — Smart Charging is ineffective.
+         * The state machine guards with !ctx->LoadBl, so OCPP limits are silently
+         * ignored even though the backend thinks they're enforced. */
+        return OCPP_LB_CONFLICT;
+    }
+
+    if (!was_standalone) {
+        /* LoadBl was non-zero when OCPP was initialized, now it's 0.
+         * The Smart Charging callback was never registered — need OCPP reinit. */
+        return OCPP_LB_NEEDS_REINIT;
+    }
+
+    return OCPP_LB_OK;
+}
+
+/* ---- Settings validation ---- */
+
+ocpp_validate_result_t ocpp_validate_backend_url(const char *url) {
+    if (!url || url[0] == '\0') {
+        return OCPP_VALIDATE_EMPTY;
+    }
+
+    /* Must start with ws:// or wss:// */
+    bool has_ws  = (strncmp(url, "ws://", 5) == 0);
+    bool has_wss = (strncmp(url, "wss://", 6) == 0);
+
+    if (!has_ws && !has_wss) {
+        return OCPP_VALIDATE_BAD_SCHEME;
+    }
+
+    /* Must have content after the scheme */
+    size_t scheme_len = has_wss ? 6 : 5;
+    if (url[scheme_len] == '\0') {
+        return OCPP_VALIDATE_BAD_SCHEME;
+    }
+
+    return OCPP_VALIDATE_OK;
+}
+
+ocpp_validate_result_t ocpp_validate_chargebox_id(const char *cb_id) {
+    if (!cb_id || cb_id[0] == '\0') {
+        return OCPP_VALIDATE_EMPTY;
+    }
+
+    size_t len = strlen(cb_id);
+
+    /* OCPP 1.6 CiString20: max 20 characters */
+    if (len > 20) {
+        return OCPP_VALIDATE_TOO_LONG;
+    }
+
+    /* Only printable ASCII allowed, no special/control chars */
+    for (size_t i = 0; i < len; i++) {
+        char c = cb_id[i];
+        if (c < 0x20 || c > 0x7E) {
+            return OCPP_VALIDATE_BAD_CHARS;
+        }
+        /* Reject chars that could cause issues in OCPP identifiers */
+        if (c == '<' || c == '>' || c == '&' || c == '"' || c == '\'') {
+            return OCPP_VALIDATE_BAD_CHARS;
+        }
+    }
+
+    return OCPP_VALIDATE_OK;
+}
+
+ocpp_validate_result_t ocpp_validate_auth_key(const char *auth_key) {
+    if (!auth_key || auth_key[0] == '\0') {
+        /* Empty auth key is acceptable (no auth) */
+        return OCPP_VALIDATE_OK;
+    }
+
+    size_t len = strlen(auth_key);
+
+    /* OCPP 1.6: max 40 characters for AuthorizationKey */
+    if (len > 40) {
+        return OCPP_VALIDATE_TOO_LONG;
+    }
+
+    return OCPP_VALIDATE_OK;
+}

--- a/SmartEVSE-3/src/ocpp_logic.h
+++ b/SmartEVSE-3/src/ocpp_logic.h
@@ -1,0 +1,121 @@
+/*
+ * ocpp_logic.h - Pure C OCPP decision logic
+ *
+ * Extracted from esp32.cpp OCPP lambdas and glue code so that authorization,
+ * connector state, RFID formatting, settings validation, and load-balancing
+ * exclusivity logic can be tested natively without MicroOcpp or Arduino.
+ *
+ * All functions operate on plain C types — no MicroOcpp, Arduino, or ESP-IDF
+ * dependencies allowed in this header.
+ */
+
+#ifndef OCPP_LOGIC_H
+#define OCPP_LOGIC_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ---- Auth path selection ---- */
+
+typedef enum {
+    OCPP_AUTH_PATH_OCPP_CONTROLLED = 0,  /* RFIDReader=0 or 6: OCPP controls Access_bit */
+    OCPP_AUTH_PATH_BUILTIN_RFID    = 1   /* RFIDReader=1..5: built-in RFID store controls, OCPP just reports */
+} ocpp_auth_path_t;
+
+ocpp_auth_path_t ocpp_select_auth_path(uint8_t rfid_reader);
+
+/* ---- Connector state ---- */
+
+bool ocpp_is_connector_plugged(uint8_t cp_voltage);
+bool ocpp_is_ev_ready(uint8_t cp_voltage);
+
+/* ---- Access decision (OCPP-controlled auth path) ---- */
+
+/*
+ * Returns true if OCPP should set Access_bit ON.
+ * Caller provides:
+ *   permits_charge       — current ocppPermitsCharge() result
+ *   prev_permits_charge  — tracked value from previous loop iteration
+ */
+bool ocpp_should_set_access(bool permits_charge, bool prev_permits_charge);
+
+/*
+ * Returns true if OCPP should clear Access_bit to OFF.
+ * Caller provides:
+ *   permits_charge  — current ocppPermitsCharge() result
+ *   access_status   — current AccessStatus (0=OFF, 1=ON, 2=PAUSE)
+ */
+bool ocpp_should_clear_access(bool permits_charge, uint8_t access_status);
+
+/* ---- RFID hex formatting ---- */
+
+#define OCPP_RFID_HEX_MAX  15  /* 7 bytes * 2 hex chars + NUL */
+
+/*
+ * Format RFID bytes as uppercase hex string.
+ *   rfid       — raw RFID bytes (7 bytes expected)
+ *   rfid_len   — number of bytes in rfid array
+ *   out        — output buffer (must be >= OCPP_RFID_HEX_MAX)
+ *   out_size   — size of output buffer
+ *
+ * Old reader format: rfid[0]==0x01 means 6-byte UID starts at rfid[1].
+ * New reader format: rfid[0]!=0x01 means 7-byte UID starts at rfid[0].
+ */
+void ocpp_format_rfid_hex(const uint8_t *rfid, size_t rfid_len,
+                          char *out, size_t out_size);
+
+/* ---- Load balancing exclusivity ---- */
+
+typedef enum {
+    OCPP_LB_OK           = 0,  /* No conflict */
+    OCPP_LB_CONFLICT     = 1,  /* LoadBl != 0 while OCPP active — Smart Charging ineffective */
+    OCPP_LB_NEEDS_REINIT = 2   /* LoadBl changed from non-zero to 0 — OCPP needs disable/enable */
+} ocpp_lb_status_t;
+
+/*
+ * Check whether OCPP Smart Charging and internal load balancing conflict.
+ *   load_bl         — current LoadBl value (0=standalone)
+ *   ocpp_mode       — true if OCPP is enabled
+ *   was_standalone   — true if LoadBl was 0 when OCPP was last initialized
+ */
+ocpp_lb_status_t ocpp_check_lb_exclusivity(uint8_t load_bl, bool ocpp_mode,
+                                           bool was_standalone);
+
+/* ---- Settings validation ---- */
+
+typedef enum {
+    OCPP_VALIDATE_OK          = 0,
+    OCPP_VALIDATE_EMPTY       = 1,
+    OCPP_VALIDATE_BAD_SCHEME  = 2,
+    OCPP_VALIDATE_TOO_LONG    = 3,
+    OCPP_VALIDATE_BAD_CHARS   = 4
+} ocpp_validate_result_t;
+
+/*
+ * Validate OCPP backend URL.
+ * Must start with "ws://" or "wss://", be non-empty, and have content after scheme.
+ */
+ocpp_validate_result_t ocpp_validate_backend_url(const char *url);
+
+/*
+ * Validate OCPP ChargeBoxId.
+ * OCPP 1.6 CiString20: max 20 chars, printable ASCII, no special chars.
+ */
+ocpp_validate_result_t ocpp_validate_chargebox_id(const char *cb_id);
+
+/*
+ * Validate OCPP auth key.
+ * OCPP 1.6: max 40 chars.
+ */
+ocpp_validate_result_t ocpp_validate_auth_key(const char *auth_key);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OCPP_LOGIC_H */

--- a/SmartEVSE-3/test/native/Makefile
+++ b/SmartEVSE-3/test/native/Makefile
@@ -24,6 +24,7 @@ MQTT_PUBLISH_SRC   := $(SRC_DIR)/mqtt_publish.c
 HTTP_API_SRC       := $(SRC_DIR)/http_api.c
 SERIAL_PARSER_SRC  := $(SRC_DIR)/serial_parser.c
 LED_COLOR_SRC      := $(SRC_DIR)/led_color.c
+OCPP_LOGIC_SRC     := $(SRC_DIR)/ocpp_logic.c
 
 # Discover all test files
 TEST_SRCS := $(wildcard $(TEST_DIR)/test_*.c)
@@ -49,6 +50,21 @@ $(BUILD)/test_serial_parser: $(TEST_DIR)/test_serial_parser.c $(SERIAL_PARSER_SR
 
 $(BUILD)/test_led_color: $(TEST_DIR)/test_led_color.c $(LED_COLOR_SRC) $(SRC_DIR)/led_color.h include/*.h | $(BUILD)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $(TEST_DIR)/test_led_color.c $(LED_COLOR_SRC)
+
+$(BUILD)/test_ocpp_auth: $(TEST_DIR)/test_ocpp_auth.c $(OCPP_LOGIC_SRC) $(SRC_DIR)/ocpp_logic.h include/*.h | $(BUILD)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $(TEST_DIR)/test_ocpp_auth.c $(OCPP_LOGIC_SRC)
+
+$(BUILD)/test_ocpp_connector: $(TEST_DIR)/test_ocpp_connector.c $(OCPP_LOGIC_SRC) $(SRC_DIR)/ocpp_logic.h include/*.h | $(BUILD)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $(TEST_DIR)/test_ocpp_connector.c $(OCPP_LOGIC_SRC)
+
+$(BUILD)/test_ocpp_rfid: $(TEST_DIR)/test_ocpp_rfid.c $(OCPP_LOGIC_SRC) $(SRC_DIR)/ocpp_logic.h include/*.h | $(BUILD)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $(TEST_DIR)/test_ocpp_rfid.c $(OCPP_LOGIC_SRC)
+
+$(BUILD)/test_ocpp_lb: $(TEST_DIR)/test_ocpp_lb.c $(OCPP_LOGIC_SRC) $(SRC_DIR)/ocpp_logic.h include/*.h | $(BUILD)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $(TEST_DIR)/test_ocpp_lb.c $(OCPP_LOGIC_SRC)
+
+$(BUILD)/test_ocpp_settings: $(TEST_DIR)/test_ocpp_settings.c $(OCPP_LOGIC_SRC) $(SRC_DIR)/ocpp_logic.h include/*.h | $(BUILD)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $(TEST_DIR)/test_ocpp_settings.c $(OCPP_LOGIC_SRC)
 
 # Build each state machine test binary (generic rule)
 $(BUILD)/test_%: $(TEST_DIR)/test_%.c $(EVSE_SRC) include/*.h $(SRC_DIR)/*.h | $(BUILD)

--- a/SmartEVSE-3/test/native/include/test_framework.h
+++ b/SmartEVSE-3/test/native/include/test_framework.h
@@ -59,6 +59,16 @@ static const char *tf_current_test = NULL;
     } \
 } while(0)
 
+#define TEST_ASSERT_EQUAL_STRING(expected, actual) do { \
+    const char *_e = (expected); const char *_a = (actual); \
+    if ((_e == NULL && _a != NULL) || (_e != NULL && _a == NULL) || \
+        (_e != NULL && _a != NULL && strcmp(_e, _a) != 0)) { \
+        printf("\n    FAIL %s:%d: expected \"%s\", got \"%s\"", __FILE__, __LINE__, \
+               _e ? _e : "(null)", _a ? _a : "(null)"); \
+        tf_current_failed = 1; \
+    } \
+} while(0)
+
 #define TEST_ASSERT_LESS_OR_EQUAL(threshold, actual) do { \
     int _t = (int)(threshold); int _a = (int)(actual); \
     if (_a > _t) { \

--- a/SmartEVSE-3/test/native/tests/test_ocpp_auth.c
+++ b/SmartEVSE-3/test/native/tests/test_ocpp_auth.c
@@ -1,0 +1,192 @@
+/*
+ * test_ocpp_auth.c - OCPP authorization logic tests
+ *
+ * Tests the pure C authorization decision functions extracted from esp32.cpp.
+ * Covers auth path selection, Access_bit set/clear decisions, and edge cases.
+ */
+
+#include "test_framework.h"
+#include "ocpp_logic.h"
+
+/* ---- Auth path selection ---- */
+
+/*
+ * @feature OCPP Authorization
+ * @req REQ-OCPP-025
+ * @scenario Auth path selection returns OCPP-controlled for RFIDReader=6
+ * @given RFIDReader is set to 6 (Rmt/OCPP mode)
+ * @when ocpp_select_auth_path is called
+ * @then Returns OCPP_AUTH_PATH_OCPP_CONTROLLED because OCPP controls Access_bit
+ */
+void test_auth_path_rfid_reader_6(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_AUTH_PATH_OCPP_CONTROLLED, ocpp_select_auth_path(6));
+}
+
+/*
+ * @feature OCPP Authorization
+ * @req REQ-OCPP-026
+ * @scenario Auth path selection returns OCPP-controlled for RFIDReader=0
+ * @given RFIDReader is set to 0 (Disabled)
+ * @when ocpp_select_auth_path is called
+ * @then Returns OCPP_AUTH_PATH_OCPP_CONTROLLED because OCPP controls Access_bit when RFID is disabled
+ */
+void test_auth_path_rfid_reader_0(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_AUTH_PATH_OCPP_CONTROLLED, ocpp_select_auth_path(0));
+}
+
+/*
+ * @feature OCPP Authorization
+ * @req REQ-OCPP-027
+ * @scenario Auth path selection returns builtin-RFID for RFIDReader=1..5
+ * @given RFIDReader is set to 1 (built-in RFID store)
+ * @when ocpp_select_auth_path is called
+ * @then Returns OCPP_AUTH_PATH_BUILTIN_RFID because built-in RFID controls charging
+ */
+void test_auth_path_rfid_reader_1(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_AUTH_PATH_BUILTIN_RFID, ocpp_select_auth_path(1));
+}
+
+/*
+ * @feature OCPP Authorization
+ * @req REQ-OCPP-027
+ * @scenario Auth path selection returns builtin-RFID for RFIDReader=5
+ * @given RFIDReader is set to 5
+ * @when ocpp_select_auth_path is called
+ * @then Returns OCPP_AUTH_PATH_BUILTIN_RFID
+ */
+void test_auth_path_rfid_reader_5(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_AUTH_PATH_BUILTIN_RFID, ocpp_select_auth_path(5));
+}
+
+/*
+ * @feature OCPP Authorization
+ * @req REQ-OCPP-027
+ * @scenario Auth path selection returns builtin-RFID for RFIDReader=3
+ * @given RFIDReader is set to 3
+ * @when ocpp_select_auth_path is called
+ * @then Returns OCPP_AUTH_PATH_BUILTIN_RFID
+ */
+void test_auth_path_rfid_reader_3(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_AUTH_PATH_BUILTIN_RFID, ocpp_select_auth_path(3));
+}
+
+/* ---- Access_bit set decision ---- */
+
+/*
+ * @feature OCPP Authorization
+ * @req REQ-OCPP-020
+ * @scenario OCPP sets Access_bit on rising edge of permits_charge
+ * @given Previous permits_charge was false
+ * @when Current permits_charge transitions to true
+ * @then ocpp_should_set_access returns true (set Access_bit ON)
+ */
+void test_should_set_access_on_rising_edge(void) {
+    TEST_ASSERT_TRUE(ocpp_should_set_access(true, false));
+}
+
+/*
+ * @feature OCPP Authorization
+ * @req REQ-OCPP-022
+ * @scenario OCPP does not re-set Access_bit if already permitted
+ * @given Previous permits_charge was already true
+ * @when Current permits_charge is still true
+ * @then ocpp_should_set_access returns false (Access_bit already set once)
+ */
+void test_should_not_set_access_when_already_permitted(void) {
+    TEST_ASSERT_FALSE(ocpp_should_set_access(true, true));
+}
+
+/*
+ * @feature OCPP Authorization
+ * @req REQ-OCPP-020
+ * @scenario OCPP does not set Access_bit when charge not permitted
+ * @given Previous permits_charge was false
+ * @when Current permits_charge is still false
+ * @then ocpp_should_set_access returns false
+ */
+void test_should_not_set_access_when_not_permitted(void) {
+    TEST_ASSERT_FALSE(ocpp_should_set_access(false, false));
+}
+
+/*
+ * @feature OCPP Authorization
+ * @req REQ-OCPP-020
+ * @scenario OCPP does not set Access_bit on falling edge
+ * @given Previous permits_charge was true
+ * @when Current permits_charge transitions to false
+ * @then ocpp_should_set_access returns false
+ */
+void test_should_not_set_access_on_falling_edge(void) {
+    TEST_ASSERT_FALSE(ocpp_should_set_access(false, true));
+}
+
+/* ---- Access_bit clear decision ---- */
+
+/*
+ * @feature OCPP Authorization
+ * @req REQ-OCPP-021
+ * @scenario OCPP clears Access_bit when permission revoked and access is ON
+ * @given AccessStatus is ON (1) and permits_charge is false
+ * @when ocpp_should_clear_access is called
+ * @then Returns true (clear Access_bit)
+ */
+void test_should_clear_access_when_revoked_and_on(void) {
+    TEST_ASSERT_TRUE(ocpp_should_clear_access(false, 1));  /* 1 = ON */
+}
+
+/*
+ * @feature OCPP Authorization
+ * @req REQ-OCPP-021
+ * @scenario OCPP does not clear Access_bit when permission is still granted
+ * @given AccessStatus is ON (1) and permits_charge is true
+ * @when ocpp_should_clear_access is called
+ * @then Returns false (Access_bit should stay)
+ */
+void test_should_not_clear_access_when_still_permitted(void) {
+    TEST_ASSERT_FALSE(ocpp_should_clear_access(true, 1));
+}
+
+/*
+ * @feature OCPP Authorization
+ * @req REQ-OCPP-021
+ * @scenario OCPP does not clear Access_bit when access is already OFF
+ * @given AccessStatus is OFF (0) and permits_charge is false
+ * @when ocpp_should_clear_access is called
+ * @then Returns false (Access_bit already cleared)
+ */
+void test_should_not_clear_access_when_already_off(void) {
+    TEST_ASSERT_FALSE(ocpp_should_clear_access(false, 0));  /* 0 = OFF */
+}
+
+/*
+ * @feature OCPP Authorization
+ * @req REQ-OCPP-021
+ * @scenario OCPP does not clear Access_bit when access is PAUSE
+ * @given AccessStatus is PAUSE (2) and permits_charge is false
+ * @when ocpp_should_clear_access is called
+ * @then Returns false because the clear logic only triggers on ON, not PAUSE
+ */
+void test_should_not_clear_access_when_paused(void) {
+    TEST_ASSERT_FALSE(ocpp_should_clear_access(false, 2));  /* 2 = PAUSE */
+}
+
+/* ---- Main ---- */
+int main(void) {
+    TEST_SUITE_BEGIN("OCPP Authorization Logic");
+
+    RUN_TEST(test_auth_path_rfid_reader_6);
+    RUN_TEST(test_auth_path_rfid_reader_0);
+    RUN_TEST(test_auth_path_rfid_reader_1);
+    RUN_TEST(test_auth_path_rfid_reader_5);
+    RUN_TEST(test_auth_path_rfid_reader_3);
+    RUN_TEST(test_should_set_access_on_rising_edge);
+    RUN_TEST(test_should_not_set_access_when_already_permitted);
+    RUN_TEST(test_should_not_set_access_when_not_permitted);
+    RUN_TEST(test_should_not_set_access_on_falling_edge);
+    RUN_TEST(test_should_clear_access_when_revoked_and_on);
+    RUN_TEST(test_should_not_clear_access_when_still_permitted);
+    RUN_TEST(test_should_not_clear_access_when_already_off);
+    RUN_TEST(test_should_not_clear_access_when_paused);
+
+    TEST_SUITE_RESULTS();
+}

--- a/SmartEVSE-3/test/native/tests/test_ocpp_connector.c
+++ b/SmartEVSE-3/test/native/tests/test_ocpp_connector.c
@@ -1,0 +1,178 @@
+/*
+ * test_ocpp_connector.c - OCPP connector state mapping tests
+ *
+ * Tests the pure C connector state functions extracted from esp32.cpp.
+ * Maps CP pilot voltage levels to OCPP connector plugged/EV-ready states.
+ */
+
+#include "test_framework.h"
+#include "ocpp_logic.h"
+#include "evse_ctx.h"
+
+/* ---- Connector plugged ---- */
+
+/*
+ * @feature OCPP Connector State
+ * @req REQ-OCPP-040
+ * @scenario CP voltage PILOT_3V indicates connector plugged
+ * @given CP voltage is PILOT_3V (3V, State C/D)
+ * @when ocpp_is_connector_plugged is called
+ * @then Returns true because PILOT_3V is within plugged range
+ */
+void test_connector_plugged_at_3v(void) {
+    TEST_ASSERT_TRUE(ocpp_is_connector_plugged(PILOT_3V));
+}
+
+/*
+ * @feature OCPP Connector State
+ * @req REQ-OCPP-040
+ * @scenario CP voltage PILOT_6V indicates connector plugged
+ * @given CP voltage is PILOT_6V (6V, State C)
+ * @when ocpp_is_connector_plugged is called
+ * @then Returns true because PILOT_6V is within plugged range
+ */
+void test_connector_plugged_at_6v(void) {
+    TEST_ASSERT_TRUE(ocpp_is_connector_plugged(PILOT_6V));
+}
+
+/*
+ * @feature OCPP Connector State
+ * @req REQ-OCPP-040
+ * @scenario CP voltage PILOT_9V indicates connector plugged
+ * @given CP voltage is PILOT_9V (9V, State B)
+ * @when ocpp_is_connector_plugged is called
+ * @then Returns true because PILOT_9V is within plugged range
+ */
+void test_connector_plugged_at_9v(void) {
+    TEST_ASSERT_TRUE(ocpp_is_connector_plugged(PILOT_9V));
+}
+
+/*
+ * @feature OCPP Connector State
+ * @req REQ-OCPP-041
+ * @scenario CP voltage PILOT_12V indicates connector unplugged
+ * @given CP voltage is PILOT_12V (12V, State A)
+ * @when ocpp_is_connector_plugged is called
+ * @then Returns false because PILOT_12V means no vehicle connected
+ */
+void test_connector_unplugged_at_12v(void) {
+    TEST_ASSERT_FALSE(ocpp_is_connector_plugged(PILOT_12V));
+}
+
+/*
+ * @feature OCPP Connector State
+ * @req REQ-OCPP-042
+ * @scenario CP voltage PILOT_NOK indicates connector unplugged
+ * @given CP voltage is PILOT_NOK (0, fault condition)
+ * @when ocpp_is_connector_plugged is called
+ * @then Returns false because PILOT_NOK is outside plugged range
+ */
+void test_connector_unplugged_at_nok(void) {
+    TEST_ASSERT_FALSE(ocpp_is_connector_plugged(PILOT_NOK));
+}
+
+/*
+ * @feature OCPP Connector State
+ * @req REQ-OCPP-042
+ * @scenario CP voltage PILOT_DIODE indicates connector unplugged
+ * @given CP voltage is PILOT_DIODE (1, diode check)
+ * @when ocpp_is_connector_plugged is called
+ * @then Returns false because PILOT_DIODE is below PILOT_3V
+ */
+void test_connector_unplugged_at_diode(void) {
+    TEST_ASSERT_FALSE(ocpp_is_connector_plugged(PILOT_DIODE));
+}
+
+/*
+ * @feature OCPP Connector State
+ * @req REQ-OCPP-042
+ * @scenario CP voltage PILOT_SHORT indicates connector unplugged
+ * @given CP voltage is PILOT_SHORT (255, short circuit)
+ * @when ocpp_is_connector_plugged is called
+ * @then Returns false because PILOT_SHORT is above PILOT_9V
+ */
+void test_connector_unplugged_at_short(void) {
+    TEST_ASSERT_FALSE(ocpp_is_connector_plugged(PILOT_SHORT));
+}
+
+/* ---- EV ready ---- */
+
+/*
+ * @feature OCPP Connector State
+ * @req REQ-OCPP-043
+ * @scenario CP voltage PILOT_3V indicates EV ready (State C/D)
+ * @given CP voltage is PILOT_3V
+ * @when ocpp_is_ev_ready is called
+ * @then Returns true because PILOT_3V is within EV-ready range
+ */
+void test_ev_ready_at_3v(void) {
+    TEST_ASSERT_TRUE(ocpp_is_ev_ready(PILOT_3V));
+}
+
+/*
+ * @feature OCPP Connector State
+ * @req REQ-OCPP-043
+ * @scenario CP voltage PILOT_6V indicates EV ready (State C)
+ * @given CP voltage is PILOT_6V
+ * @when ocpp_is_ev_ready is called
+ * @then Returns true because PILOT_6V is within EV-ready range
+ */
+void test_ev_ready_at_6v(void) {
+    TEST_ASSERT_TRUE(ocpp_is_ev_ready(PILOT_6V));
+}
+
+/*
+ * @feature OCPP Connector State
+ * @req REQ-OCPP-044
+ * @scenario CP voltage PILOT_9V indicates EV connected but not ready (State B)
+ * @given CP voltage is PILOT_9V
+ * @when ocpp_is_ev_ready is called
+ * @then Returns false because State B means connected but not requesting charge
+ */
+void test_ev_not_ready_at_9v(void) {
+    TEST_ASSERT_FALSE(ocpp_is_ev_ready(PILOT_9V));
+}
+
+/*
+ * @feature OCPP Connector State
+ * @req REQ-OCPP-044
+ * @scenario CP voltage PILOT_12V indicates no EV (State A)
+ * @given CP voltage is PILOT_12V
+ * @when ocpp_is_ev_ready is called
+ * @then Returns false because no vehicle is connected
+ */
+void test_ev_not_ready_at_12v(void) {
+    TEST_ASSERT_FALSE(ocpp_is_ev_ready(PILOT_12V));
+}
+
+/*
+ * @feature OCPP Connector State
+ * @req REQ-OCPP-044
+ * @scenario CP voltage PILOT_NOK indicates EV not ready
+ * @given CP voltage is PILOT_NOK (fault)
+ * @when ocpp_is_ev_ready is called
+ * @then Returns false
+ */
+void test_ev_not_ready_at_nok(void) {
+    TEST_ASSERT_FALSE(ocpp_is_ev_ready(PILOT_NOK));
+}
+
+/* ---- Main ---- */
+int main(void) {
+    TEST_SUITE_BEGIN("OCPP Connector State");
+
+    RUN_TEST(test_connector_plugged_at_3v);
+    RUN_TEST(test_connector_plugged_at_6v);
+    RUN_TEST(test_connector_plugged_at_9v);
+    RUN_TEST(test_connector_unplugged_at_12v);
+    RUN_TEST(test_connector_unplugged_at_nok);
+    RUN_TEST(test_connector_unplugged_at_diode);
+    RUN_TEST(test_connector_unplugged_at_short);
+    RUN_TEST(test_ev_ready_at_3v);
+    RUN_TEST(test_ev_ready_at_6v);
+    RUN_TEST(test_ev_not_ready_at_9v);
+    RUN_TEST(test_ev_not_ready_at_12v);
+    RUN_TEST(test_ev_not_ready_at_nok);
+
+    TEST_SUITE_RESULTS();
+}

--- a/SmartEVSE-3/test/native/tests/test_ocpp_lb.c
+++ b/SmartEVSE-3/test/native/tests/test_ocpp_lb.c
@@ -1,0 +1,108 @@
+/*
+ * test_ocpp_lb.c - OCPP + Load Balancing exclusivity tests
+ *
+ * Tests the pure C function that detects conflicts between OCPP Smart Charging
+ * and internal load balancing. The OCPP Smart Charging callback is only registered
+ * at ocppInit() time when LoadBl=0, but LoadBl can change at runtime.
+ */
+
+#include "test_framework.h"
+#include "ocpp_logic.h"
+
+/* ---- No conflict: standalone mode ---- */
+
+/*
+ * @feature OCPP Load Balancing Exclusivity
+ * @req REQ-OCPP-030
+ * @scenario OCPP+LoadBl=0 has no conflict, Smart Charging active
+ * @given OCPP is enabled, LoadBl=0 (standalone), and OCPP was initialized in standalone mode
+ * @when ocpp_check_lb_exclusivity is called
+ * @then Returns OCPP_LB_OK because Smart Charging and LoadBl are compatible
+ */
+void test_lb_standalone_no_conflict(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_LB_OK,
+        ocpp_check_lb_exclusivity(0, true, true));
+}
+
+/*
+ * @feature OCPP Load Balancing Exclusivity
+ * @req REQ-OCPP-030
+ * @scenario OCPP disabled has no conflict regardless of LoadBl
+ * @given OCPP is disabled, LoadBl=1
+ * @when ocpp_check_lb_exclusivity is called
+ * @then Returns OCPP_LB_OK because OCPP is not active
+ */
+void test_lb_ocpp_disabled_no_conflict(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_LB_OK,
+        ocpp_check_lb_exclusivity(1, false, false));
+}
+
+/* ---- Conflict: LoadBl != 0 while OCPP active ---- */
+
+/*
+ * @feature OCPP Load Balancing Exclusivity
+ * @req REQ-OCPP-031
+ * @scenario OCPP+LoadBl=1 is a conflict, Smart Charging ineffective
+ * @given OCPP is enabled, LoadBl=1 (master), OCPP was initialized standalone
+ * @when ocpp_check_lb_exclusivity is called
+ * @then Returns OCPP_LB_CONFLICT because the state machine ignores OCPP limits when LoadBl!=0
+ */
+void test_lb_master_conflict(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_LB_CONFLICT,
+        ocpp_check_lb_exclusivity(1, true, true));
+}
+
+/*
+ * @feature OCPP Load Balancing Exclusivity
+ * @req REQ-OCPP-031
+ * @scenario OCPP+LoadBl=2 (node) is a conflict
+ * @given OCPP is enabled, LoadBl=2 (node), OCPP was initialized standalone
+ * @when ocpp_check_lb_exclusivity is called
+ * @then Returns OCPP_LB_CONFLICT
+ */
+void test_lb_node_conflict(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_LB_CONFLICT,
+        ocpp_check_lb_exclusivity(2, true, true));
+}
+
+/*
+ * @feature OCPP Load Balancing Exclusivity
+ * @req REQ-OCPP-032
+ * @scenario LoadBl changes from 0 to 1 while OCPP active is a conflict
+ * @given OCPP is enabled, LoadBl changed to 1 at runtime, was_standalone=true
+ * @when ocpp_check_lb_exclusivity is called
+ * @then Returns OCPP_LB_CONFLICT because Smart Charging callback is still registered but limits are ignored
+ */
+void test_lb_changed_0_to_1_conflict(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_LB_CONFLICT,
+        ocpp_check_lb_exclusivity(1, true, true));
+}
+
+/* ---- Needs reinit: LoadBl was non-zero at init, now zero ---- */
+
+/*
+ * @feature OCPP Load Balancing Exclusivity
+ * @req REQ-OCPP-033
+ * @scenario LoadBl changes from 1 to 0 while OCPP active needs reinit
+ * @given OCPP is enabled, LoadBl=0 now, but was_standalone=false (was non-zero at init)
+ * @when ocpp_check_lb_exclusivity is called
+ * @then Returns OCPP_LB_NEEDS_REINIT because Smart Charging callback was never registered
+ */
+void test_lb_changed_1_to_0_needs_reinit(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_LB_NEEDS_REINIT,
+        ocpp_check_lb_exclusivity(0, true, false));
+}
+
+/* ---- Main ---- */
+int main(void) {
+    TEST_SUITE_BEGIN("OCPP Load Balancing Exclusivity");
+
+    RUN_TEST(test_lb_standalone_no_conflict);
+    RUN_TEST(test_lb_ocpp_disabled_no_conflict);
+    RUN_TEST(test_lb_master_conflict);
+    RUN_TEST(test_lb_node_conflict);
+    RUN_TEST(test_lb_changed_0_to_1_conflict);
+    RUN_TEST(test_lb_changed_1_to_0_needs_reinit);
+
+    TEST_SUITE_RESULTS();
+}

--- a/SmartEVSE-3/test/native/tests/test_ocpp_rfid.c
+++ b/SmartEVSE-3/test/native/tests/test_ocpp_rfid.c
@@ -1,0 +1,139 @@
+/*
+ * test_ocpp_rfid.c - OCPP RFID hex formatting tests
+ *
+ * Tests the pure C RFID-to-hex conversion extracted from esp32.cpp ocppLoop().
+ * The function must handle old reader format (rfid[0]==0x01, 6-byte UID at [1])
+ * and new reader format (7-byte UID at [0]).
+ */
+
+#include "test_framework.h"
+#include "ocpp_logic.h"
+#include <string.h>
+
+/* ---- New reader format (7-byte UID) ---- */
+
+/*
+ * @feature OCPP RFID Formatting
+ * @req REQ-OCPP-054
+ * @scenario New reader 7-byte UUID formatted as 14-char hex string
+ * @given RFID bytes {0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67} (new reader)
+ * @when ocpp_format_rfid_hex is called
+ * @then Output is "ABCDEF01234567" (7 bytes * 2 hex chars)
+ */
+void test_rfid_new_reader_7byte(void) {
+    uint8_t rfid[] = {0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67};
+    char out[OCPP_RFID_HEX_MAX];
+    ocpp_format_rfid_hex(rfid, 7, out, sizeof(out));
+    TEST_ASSERT_EQUAL_STRING("ABCDEF01234567", out);
+}
+
+/*
+ * @feature OCPP RFID Formatting
+ * @req REQ-OCPP-052
+ * @scenario UUID with leading zeros preserved in hex output
+ * @given RFID bytes {0x00, 0x00, 0x0A, 0x0B, 0x00, 0x00, 0x00} (new reader with leading zeros)
+ * @when ocpp_format_rfid_hex is called
+ * @then Output is "0000 0A0B000000" with leading zeros preserved
+ */
+void test_rfid_leading_zeros_preserved(void) {
+    uint8_t rfid[] = {0x00, 0x00, 0x0A, 0x0B, 0x00, 0x00, 0x00};
+    char out[OCPP_RFID_HEX_MAX];
+    ocpp_format_rfid_hex(rfid, 7, out, sizeof(out));
+    TEST_ASSERT_EQUAL_STRING("00000A0B000000", out);
+}
+
+/* ---- Old reader format (rfid[0]==0x01, 6-byte UID at [1]) ---- */
+
+/*
+ * @feature OCPP RFID Formatting
+ * @req REQ-OCPP-053
+ * @scenario Old reader format uses RFID[1..6] offset
+ * @given RFID bytes {0x01, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF} (old reader flag at [0])
+ * @when ocpp_format_rfid_hex is called
+ * @then Output is "AABBCCDDEEFF" (6 bytes from [1] to [6])
+ */
+void test_rfid_old_reader_6byte(void) {
+    uint8_t rfid[] = {0x01, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    char out[OCPP_RFID_HEX_MAX];
+    ocpp_format_rfid_hex(rfid, 7, out, sizeof(out));
+    TEST_ASSERT_EQUAL_STRING("AABBCCDDEEFF", out);
+}
+
+/*
+ * @feature OCPP RFID Formatting
+ * @req REQ-OCPP-053
+ * @scenario Old reader with leading zero bytes preserved
+ * @given RFID bytes {0x01, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04} (old reader)
+ * @when ocpp_format_rfid_hex is called
+ * @then Output is "000001020304" with leading zeros from [1] preserved
+ */
+void test_rfid_old_reader_leading_zeros(void) {
+    uint8_t rfid[] = {0x01, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04};
+    char out[OCPP_RFID_HEX_MAX];
+    ocpp_format_rfid_hex(rfid, 7, out, sizeof(out));
+    TEST_ASSERT_EQUAL_STRING("000001020304", out);
+}
+
+/* ---- 4-byte UID (short format, new reader) ---- */
+
+/*
+ * @feature OCPP RFID Formatting
+ * @req REQ-OCPP-050
+ * @scenario 4-byte UUID formatted as 8-char hex string
+ * @given RFID bytes {0xDE, 0xAD, 0xBE, 0xEF} (4-byte UID, new reader)
+ * @when ocpp_format_rfid_hex is called with rfid_len=4
+ * @then Output is "DEADBEEF" (4 bytes * 2 hex chars)
+ */
+void test_rfid_4byte_new_reader(void) {
+    uint8_t rfid[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    char out[OCPP_RFID_HEX_MAX];
+    ocpp_format_rfid_hex(rfid, 4, out, sizeof(out));
+    TEST_ASSERT_EQUAL_STRING("DEADBEEF", out);
+}
+
+/* ---- Edge cases ---- */
+
+/*
+ * @feature OCPP RFID Formatting
+ * @req REQ-OCPP-050
+ * @scenario NULL RFID input produces empty string
+ * @given RFID pointer is NULL
+ * @when ocpp_format_rfid_hex is called
+ * @then Output is empty string
+ */
+void test_rfid_null_input(void) {
+    char out[OCPP_RFID_HEX_MAX];
+    out[0] = 'X';  /* Pre-fill to detect overwrite */
+    ocpp_format_rfid_hex(NULL, 0, out, sizeof(out));
+    TEST_ASSERT_EQUAL_STRING("", out);
+}
+
+/*
+ * @feature OCPP RFID Formatting
+ * @req REQ-OCPP-050
+ * @scenario Zero-length RFID produces empty string
+ * @given RFID bytes exist but length is 0
+ * @when ocpp_format_rfid_hex is called
+ * @then Output is empty string
+ */
+void test_rfid_zero_length(void) {
+    uint8_t rfid[] = {0xAA};
+    char out[OCPP_RFID_HEX_MAX];
+    ocpp_format_rfid_hex(rfid, 0, out, sizeof(out));
+    TEST_ASSERT_EQUAL_STRING("", out);
+}
+
+/* ---- Main ---- */
+int main(void) {
+    TEST_SUITE_BEGIN("OCPP RFID Formatting");
+
+    RUN_TEST(test_rfid_new_reader_7byte);
+    RUN_TEST(test_rfid_leading_zeros_preserved);
+    RUN_TEST(test_rfid_old_reader_6byte);
+    RUN_TEST(test_rfid_old_reader_leading_zeros);
+    RUN_TEST(test_rfid_4byte_new_reader);
+    RUN_TEST(test_rfid_null_input);
+    RUN_TEST(test_rfid_zero_length);
+
+    TEST_SUITE_RESULTS();
+}

--- a/SmartEVSE-3/test/native/tests/test_ocpp_settings.c
+++ b/SmartEVSE-3/test/native/tests/test_ocpp_settings.c
@@ -1,0 +1,276 @@
+/*
+ * test_ocpp_settings.c - OCPP settings validation tests
+ *
+ * Tests the pure C validation functions for OCPP backend URL, ChargeBoxId,
+ * and auth key. Currently esp32.cpp passes these values to MicroOcpp without
+ * validation — these functions add input checking.
+ */
+
+#include "test_framework.h"
+#include "ocpp_logic.h"
+
+/* ---- Backend URL validation ---- */
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-060
+ * @scenario Valid wss:// URL accepted
+ * @given URL is "wss://ocpp.example.com/smartevse"
+ * @when ocpp_validate_backend_url is called
+ * @then Returns OCPP_VALIDATE_OK
+ */
+void test_url_valid_wss(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_OK,
+        ocpp_validate_backend_url("wss://ocpp.example.com/smartevse"));
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-061
+ * @scenario Valid ws:// URL accepted
+ * @given URL is "ws://192.168.1.100:8180/steve/websocket/CentralSystemService"
+ * @when ocpp_validate_backend_url is called
+ * @then Returns OCPP_VALIDATE_OK
+ */
+void test_url_valid_ws(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_OK,
+        ocpp_validate_backend_url("ws://192.168.1.100:8180/steve/websocket/CentralSystemService"));
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-062
+ * @scenario URL without ws/wss scheme rejected
+ * @given URL is "http://ocpp.example.com"
+ * @when ocpp_validate_backend_url is called
+ * @then Returns OCPP_VALIDATE_BAD_SCHEME
+ */
+void test_url_http_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_BAD_SCHEME,
+        ocpp_validate_backend_url("http://ocpp.example.com"));
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-062
+ * @scenario URL with https scheme rejected
+ * @given URL is "https://ocpp.example.com"
+ * @when ocpp_validate_backend_url is called
+ * @then Returns OCPP_VALIDATE_BAD_SCHEME
+ */
+void test_url_https_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_BAD_SCHEME,
+        ocpp_validate_backend_url("https://ocpp.example.com"));
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-063
+ * @scenario Empty URL rejected
+ * @given URL is empty string
+ * @when ocpp_validate_backend_url is called
+ * @then Returns OCPP_VALIDATE_EMPTY
+ */
+void test_url_empty_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_EMPTY,
+        ocpp_validate_backend_url(""));
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-063
+ * @scenario NULL URL rejected
+ * @given URL pointer is NULL
+ * @when ocpp_validate_backend_url is called
+ * @then Returns OCPP_VALIDATE_EMPTY
+ */
+void test_url_null_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_EMPTY,
+        ocpp_validate_backend_url(NULL));
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-062
+ * @scenario Bare scheme without host rejected
+ * @given URL is "ws://" with no host
+ * @when ocpp_validate_backend_url is called
+ * @then Returns OCPP_VALIDATE_BAD_SCHEME because there is no content after scheme
+ */
+void test_url_bare_scheme_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_BAD_SCHEME,
+        ocpp_validate_backend_url("ws://"));
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-062
+ * @scenario Bare wss scheme without host rejected
+ * @given URL is "wss://" with no host
+ * @when ocpp_validate_backend_url is called
+ * @then Returns OCPP_VALIDATE_BAD_SCHEME
+ */
+void test_url_bare_wss_scheme_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_BAD_SCHEME,
+        ocpp_validate_backend_url("wss://"));
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-062
+ * @scenario Plain text without scheme rejected
+ * @given URL is "ocpp.example.com" (no ws:// prefix)
+ * @when ocpp_validate_backend_url is called
+ * @then Returns OCPP_VALIDATE_BAD_SCHEME
+ */
+void test_url_no_scheme_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_BAD_SCHEME,
+        ocpp_validate_backend_url("ocpp.example.com"));
+}
+
+/* ---- ChargeBoxId validation ---- */
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-064
+ * @scenario Valid ChargeBoxId accepted
+ * @given ChargeBoxId is "SmartEVSE-12345"
+ * @when ocpp_validate_chargebox_id is called
+ * @then Returns OCPP_VALIDATE_OK
+ */
+void test_cbid_valid(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_OK,
+        ocpp_validate_chargebox_id("SmartEVSE-12345"));
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-064
+ * @scenario ChargeBoxId with special characters rejected
+ * @given ChargeBoxId contains '<' character
+ * @when ocpp_validate_chargebox_id is called
+ * @then Returns OCPP_VALIDATE_BAD_CHARS
+ */
+void test_cbid_special_chars_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_BAD_CHARS,
+        ocpp_validate_chargebox_id("Smart<EVSE>"));
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-065
+ * @scenario ChargeBoxId length > 20 rejected (OCPP 1.6 CiString20)
+ * @given ChargeBoxId is 21 characters long
+ * @when ocpp_validate_chargebox_id is called
+ * @then Returns OCPP_VALIDATE_TOO_LONG
+ */
+void test_cbid_too_long_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_TOO_LONG,
+        ocpp_validate_chargebox_id("123456789012345678901"));  /* 21 chars */
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-065
+ * @scenario ChargeBoxId exactly 20 characters is accepted
+ * @given ChargeBoxId is exactly 20 characters long
+ * @when ocpp_validate_chargebox_id is called
+ * @then Returns OCPP_VALIDATE_OK
+ */
+void test_cbid_exactly_20_accepted(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_OK,
+        ocpp_validate_chargebox_id("12345678901234567890"));  /* 20 chars */
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-064
+ * @scenario Empty ChargeBoxId rejected
+ * @given ChargeBoxId is empty string
+ * @when ocpp_validate_chargebox_id is called
+ * @then Returns OCPP_VALIDATE_EMPTY
+ */
+void test_cbid_empty_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_EMPTY,
+        ocpp_validate_chargebox_id(""));
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-064
+ * @scenario ChargeBoxId with ampersand rejected
+ * @given ChargeBoxId contains '&' character
+ * @when ocpp_validate_chargebox_id is called
+ * @then Returns OCPP_VALIDATE_BAD_CHARS
+ */
+void test_cbid_ampersand_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_BAD_CHARS,
+        ocpp_validate_chargebox_id("Smart&EVSE"));
+}
+
+/* ---- Auth key validation ---- */
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-066
+ * @scenario Auth key length > 40 rejected (OCPP 1.6 limit)
+ * @given Auth key is 41 characters long
+ * @when ocpp_validate_auth_key is called
+ * @then Returns OCPP_VALIDATE_TOO_LONG
+ */
+void test_auth_key_too_long(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_TOO_LONG,
+        ocpp_validate_auth_key("12345678901234567890123456789012345678901"));  /* 41 chars */
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-066
+ * @scenario Auth key exactly 40 characters is accepted
+ * @given Auth key is exactly 40 characters long
+ * @when ocpp_validate_auth_key is called
+ * @then Returns OCPP_VALIDATE_OK
+ */
+void test_auth_key_exactly_40_accepted(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_OK,
+        ocpp_validate_auth_key("1234567890123456789012345678901234567890"));  /* 40 chars */
+}
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-066
+ * @scenario Empty auth key is valid (no auth configured)
+ * @given Auth key is empty string
+ * @when ocpp_validate_auth_key is called
+ * @then Returns OCPP_VALIDATE_OK because empty means no auth
+ */
+void test_auth_key_empty_accepted(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_OK,
+        ocpp_validate_auth_key(""));
+}
+
+/* ---- Main ---- */
+int main(void) {
+    TEST_SUITE_BEGIN("OCPP Settings Validation");
+
+    RUN_TEST(test_url_valid_wss);
+    RUN_TEST(test_url_valid_ws);
+    RUN_TEST(test_url_http_rejected);
+    RUN_TEST(test_url_https_rejected);
+    RUN_TEST(test_url_empty_rejected);
+    RUN_TEST(test_url_null_rejected);
+    RUN_TEST(test_url_bare_scheme_rejected);
+    RUN_TEST(test_url_bare_wss_scheme_rejected);
+    RUN_TEST(test_url_no_scheme_rejected);
+    RUN_TEST(test_cbid_valid);
+    RUN_TEST(test_cbid_special_chars_rejected);
+    RUN_TEST(test_cbid_too_long_rejected);
+    RUN_TEST(test_cbid_exactly_20_accepted);
+    RUN_TEST(test_cbid_empty_rejected);
+    RUN_TEST(test_cbid_ampersand_rejected);
+    RUN_TEST(test_auth_key_too_long);
+    RUN_TEST(test_auth_key_exactly_40_accepted);
+    RUN_TEST(test_auth_key_empty_accepted);
+
+    TEST_SUITE_RESULTS();
+}


### PR DESCRIPTION
## Summary

- Extract testable pure C OCPP decision functions from `esp32.cpp` lambdas into new `ocpp_logic.h/c` module
- Add 5 new test suites (56 tests) covering authorization, connector state, RFID formatting, LB exclusivity, and settings validation
- Add missing `PILOT_3V` constant to `evse_ctx.h` and `TEST_ASSERT_EQUAL_STRING` macro to test framework

## Details

**New module `ocpp_logic.h/c`** — pure C, zero platform dependencies:
- `ocpp_select_auth_path()` — OCPP-controlled vs builtin-RFID auth path
- `ocpp_is_connector_plugged()` / `ocpp_is_ev_ready()` — CP voltage mapping
- `ocpp_should_set_access()` / `ocpp_should_clear_access()` — Access_bit decisions
- `ocpp_format_rfid_hex()` — RFID bytes to hex (old/new reader formats)
- `ocpp_check_lb_exclusivity()` — LoadBl + OCPP Smart Charging conflict detection
- `ocpp_validate_backend_url()` / `ocpp_validate_chargebox_id()` / `ocpp_validate_auth_key()`

**Test coverage:** REQ-OCPP-020 through REQ-OCPP-066 with full SbE annotations.

## Test plan

- [x] `make clean test` — 29 suites, all pass
- [x] Sanitizer build (ASan + UBSan) — all pass
- [x] `cppcheck` on `ocpp_logic.c` — clean
- [x] ESP32 firmware build — SUCCESS (85.0% flash, 21.1% RAM)
- [x] CH32 firmware build — SUCCESS (62.4% flash, 19.9% RAM)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)