### PR TITLE
fix: resolve CodeQL stack-address-escape in modbus_decode

### DIFF
--- a/SmartEVSE-3/src/modbus_decode.c
+++ b/SmartEVSE-3/src/modbus_decode.c
@@ -95,10 +95,13 @@ void modbus_decode(modbus_frame_t *frame, const uint8_t *buf, uint8_t len)
             break;
     }
 
-    /* Set Data pointer if we have data */
+    /* Copy data into owned buffer if we have data */
     if (frame->Type != MODBUS_INVALID && frame->DataLength > 0) {
-        /* Data is at the end of the buffer, length DataLength bytes */
-        frame->Data = (uint8_t *)(buf + (len - frame->DataLength));
+        uint8_t copy_len = frame->DataLength;
+        if (copy_len > MODBUS_MAX_DATA) copy_len = MODBUS_MAX_DATA;
+        memcpy(frame->DataBuf, buf + (len - frame->DataLength), copy_len);
+        frame->Data = frame->DataBuf;
+        frame->DataLength = copy_len;
     }
 
     /* Request-Response matching logic */

--- a/SmartEVSE-3/src/modbus_decode.h
+++ b/SmartEVSE-3/src/modbus_decode.h
@@ -24,10 +24,13 @@ extern "C" {
 /* Default broadcast address */
 #define MODBUS_BROADCAST_ADR 0x09
 
+/* Maximum data bytes stored in frame (covers Sensorbox 64-byte payloads) */
+#define MODBUS_MAX_DATA 128
+
 /*
  * Parsed Modbus frame.
- * Mirrors the existing firmware `struct ModBus` layout so the glue layer
- * can memcpy between them during the transition period.
+ * Data is copied into an internal buffer (DataBuf) so the frame owns its
+ * data and does not hold pointers into the caller's buffer.
  */
 typedef struct {
     uint8_t  Address;
@@ -35,7 +38,8 @@ typedef struct {
     uint16_t Register;
     uint16_t RegisterCount;
     uint16_t Value;
-    uint8_t  *Data;
+    uint8_t  DataBuf[MODBUS_MAX_DATA]; /* Owned copy of payload data */
+    uint8_t  *Data;                    /* Points into DataBuf (or NULL) */
     uint8_t  DataLength;
     uint8_t  Type;          /* MODBUS_INVALID / MODBUS_REQUEST / etc. */
     uint8_t  RequestAddress;

--- a/SmartEVSE-3/test/modbus/decode_bridge.py
+++ b/SmartEVSE-3/test/modbus/decode_bridge.py
@@ -53,6 +53,7 @@ class ModbusFrame(ctypes.Structure):
         ('Register', ctypes.c_uint16),
         ('RegisterCount', ctypes.c_uint16),
         ('Value', ctypes.c_uint16),
+        ('DataBuf', ctypes.c_uint8 * 128),
         ('Data', ctypes.POINTER(ctypes.c_uint8)),
         ('DataLength', ctypes.c_uint8),
         ('Type', ctypes.c_uint8),


### PR DESCRIPTION
## Summary
- Resolves CodeQL alert #4: `cpp/stack-address-escape` in `modbus_decode.c:101`
- `frame->Data` previously pointed into the caller's `buf` parameter — a potential dangling pointer if `buf` is stack-local
- Added 128-byte `DataBuf` to `modbus_frame_t` and `memcpy` payload data into it
- `Data` now points into the struct's own buffer, eliminating the external pointer
- Updated ctypes bridge (`decode_bridge.py`) to match new struct layout

## Test plan
- [x] 44 native test suites pass (900+ tests)
- [x] ASAN/UBSAN clean
- [x] cppcheck clean
- [x] ESP32 build: Flash 85.6%, RAM 23.9%
- [x] CH32 build: Flash 63.5%, RAM 20.8%

🤖 Generated with [Claude Code](https://claude.com/claude-code)