### PR TITLE
fix: release workflow + nightly signing for basmeerman OTA

### DIFF
--- a/.github/workflows/nightly-debug.yaml
+++ b/.github/workflows/nightly-debug.yaml
@@ -57,16 +57,16 @@ jobs:
         env:
           super_secret: ${{ secrets.SECRET_RSA_KEY }}
         run: |
+          cp ./SmartEVSE-3/.pio/build/release/firmware.bin ./dist/firmware.bin
           if [ -z "$super_secret" ]; then
-            echo "Signing key not available, shipping unsigned"
-            cp ./SmartEVSE-3/.pio/build/release/firmware.bin ./dist/firmware.bin
-            exit 0
+            echo "Signing key not available — unsigned firmware only"
+          else
+            secret_file=$(mktemp)
+            echo "$super_secret" > "$secret_file"
+            openssl dgst -sign "$secret_file" -keyform PEM -sha256 -out firmware.sign -binary ./dist/firmware.bin
+            cat firmware.sign ./dist/firmware.bin > ./dist/firmware.signed.bin
+            rm -f "$secret_file" firmware.sign
           fi
-          secret_file=$(mktemp)
-          echo "$super_secret" > "$secret_file"
-          openssl dgst -sign "$secret_file" -keyform PEM -sha256 -out firmware.sign -binary ./SmartEVSE-3/.pio/build/release/firmware.bin
-          cat firmware.sign ./SmartEVSE-3/.pio/build/release/firmware.bin > ./dist/firmware.signed.bin
-          rm -f "$secret_file"
 
       - name: Build debug firmware
         run: |
@@ -76,16 +76,16 @@ jobs:
         env:
           super_secret: ${{ secrets.SECRET_RSA_KEY }}
         run: |
+          cp ./SmartEVSE-3/.pio/build/release/firmware.bin ./dist/firmware.debug.bin
           if [ -z "$super_secret" ]; then
-            echo "Signing key not available, shipping unsigned"
-            cp ./SmartEVSE-3/.pio/build/release/firmware.bin ./dist/firmware.debug.bin
-            exit 0
+            echo "Signing key not available — unsigned firmware only"
+          else
+            secret_file=$(mktemp)
+            echo "$super_secret" > "$secret_file"
+            openssl dgst -sign "$secret_file" -keyform PEM -sha256 -out firmware.sign -binary ./dist/firmware.debug.bin
+            cat firmware.sign ./dist/firmware.debug.bin > ./dist/firmware.debug.signed.bin
+            rm -f "$secret_file" firmware.sign
           fi
-          secret_file=$(mktemp)
-          echo "$super_secret" > "$secret_file"
-          openssl dgst -sign "$secret_file" -keyform PEM -sha256 -out firmware.sign -binary ./SmartEVSE-3/.pio/build/release/firmware.bin
-          cat firmware.sign ./SmartEVSE-3/.pio/build/release/firmware.bin > ./dist/firmware.debug.signed.bin
-          rm -f "$secret_file"
 
       - name: Delete existing nightly release
         run: gh release delete nightly --yes --cleanup-tag 2>/dev/null || true

--- a/.github/workflows/pio-release.yaml
+++ b/.github/workflows/pio-release.yaml
@@ -73,11 +73,13 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
           draft: false
-          prerelease: true
+          prerelease: false
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             ${{ steps.tag.outputs.tag }}-dist.zip
+            dist/firmware.bin
             dist/firmware.signed.bin
+            dist/firmware.debug.bin
             dist/firmware.debug.signed.bin
             SmartEVSE-3/test/native/traceability-report.html
 


### PR DESCRIPTION
## Summary

Fixes the two root causes preventing the basmeerman update page buttons from working:

**Issue 3A: Tagged releases invisible to /releases/latest API**
- Changed `prerelease: false` in pio-release.yaml (was `true`)
- Added individual firmware files as release assets (`.bin` and `.signed.bin`)

**Issue 3B: Nightly produces correct signed filenames**
- Always produces `.bin` (unsigned)
- Produces `.signed.bin` when `SECRET_RSA_KEY` is configured
- Both standard and debug variants

## Prerequisites

`SECRET_RSA_KEY` must be added to repo secrets for OTA to work (firmware validates RSA signature).

## Test plan

- [x] ESP32 build succeeds
- [ ] After adding SECRET_RSA_KEY: create tag → verify release has individual firmware files
- [ ] After adding SECRET_RSA_KEY: push to master → verify nightly has signed firmware
- [ ] OTA: Standard button downloads and flashes successfully
- [ ] OTA: Debug button downloads and flashes successfully
- [ ] OTA: Latest Debug Build button downloads nightly and flashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)