### PR TITLE
docs: upstream integration process and initial sync triage

### DIFF
--- a/docs/upstream-differences.md
+++ b/docs/upstream-differences.md
@@ -40,7 +40,7 @@ Addresses upstream issues
 | Symmetric ramp rates | Overshoot/undershoot from asymmetric regulation | [Features: Solar & Smart Mode](features.md#solar--smart-mode) |
 | Tiered phase switching timers | Rapid 1P/3P cycling | [Features: Solar & Smart Mode](features.md#solar--smart-mode) |
 | Stop/start cycling prevention | Solar mode stops and restarts unnecessarily | [Features: Solar & Smart Mode](features.md#solar--smart-mode) |
-| Multi-node SolarStopTimer fix | Upstream threshold scales with ActiveEVSE, unreachable for 2+ nodes (commit `94ca08e`) | [PR #119](https://github.com/basmeerman/SmartEVSE-3.5/pull/119) |
+| Multi-node SolarStopTimer fix | Upstream threshold scales with `ActiveEVSE`, unreachable for 2+ nodes (commit `94ca08e`). Upstream attempted a different fix in `02dafa2` that we evaluated and rejected — it reproduces the multi-node scaling bug and causes stop/start cycling for fixed 3-phase. See [analysis](upstream-sync/analysis-02dafa2-solar-stop-threshold.md). | [PR #119](https://github.com/basmeerman/SmartEVSE-3.5/pull/119) |
 | Slave mode sync via setMode() | Upstream `SETITEM(MENU_MODE)` skips phase switching and error clearing on slaves | [PR #121](https://github.com/basmeerman/SmartEVSE-3.5/pull/121) |
 | Slow EV compatibility | Renault Zoe stalls on rapid current changes | [Features: Solar & Smart Mode](features.md#solar--smart-mode) |
 

--- a/docs/upstream-sync/analysis-02dafa2-solar-stop-threshold.md
+++ b/docs/upstream-sync/analysis-02dafa2-solar-stop-threshold.md
@@ -1,0 +1,238 @@
+# Analysis: Upstream Commit 02dafa2 vs Fork PR #119
+
+## Solar Stop Timer Threshold Comparison
+
+Both fixes address the same bug: the SolarStopTimer threshold was unreachable
+in multi-node setups. They take different approaches.
+
+### What the EVSE Knows
+
+The EVSE has ONE measurement from the mains meter:
+
+- **Isum** = L1 + L2 + L3 at the grid connection (sum of all phases)
+  - **Positive** = importing from grid (drawing more than solar produces)
+  - **Negative** = exporting to grid (solar surplus)
+  - **Zero** = perfectly balanced
+
+Everything behind the meter (house loads, solar panels, EV charger) is
+invisible to the EVSE — it only sees the net result at the grid point.
+
+**Key settings:**
+- **MinCurrent** = 6A per phase (minimum charge current, IEC 61851)
+- **StartCurrent** = 4A (minimum export needed to START a charge session)
+
+### Solar Mode Behavior
+
+The EVSE regulates its charging current to keep Isum near zero:
+- Isum going negative → solar surplus → can increase charge current
+- Isum going positive → grid import → must reduce charge current
+- Isum stays positive too long → stop charging
+
+### Phase Switching Happens FIRST
+
+When the EVSE detects shortage (grid importing), the sequence is:
+
+```
+Isum positive (importing) → shortage
+  ↓
+Still on 3 phases? (EnableC2=AUTO)
+  YES → Switch to 1 phase first (PhaseSwitchTimer)
+        This reduces the EVSE's draw from 18A to 6A
+        Isum drops by ~12A
+  ↓
+Already on 1 phase → is Isum STILL too high?
+  YES → Start SolarStopTimer (eventually stop charging)
+  NO  → Keep charging on 1 phase
+```
+
+**By the time the SolarStopTimer fires, the car is on 1 phase (6A).**
+
+### The Threshold Question
+
+"If I stop the last active car, would it immediately restart?"
+
+The car draws 6A (1-phase) from the house side of the meter. If we stop it,
+Isum drops by 6A. After stopping:
+
+```
+Isum_after = Isum - 6A
+```
+
+**Restart condition** (code line 469): charging starts when `Isum < -4A`
+(grid exporting more than 4A = StartCurrent).
+
+- At `Isum = 3A`: stop → `Isum_after = -3A`. Is -3 < -4? NO. Won't restart. ✓
+- At `Isum = 1A`: stop → `Isum_after = -5A`. Is -5 < -4? YES. Would restart! ✗
+
+**Correct threshold = 2A** (6A draw − 4A start tolerance).
+Timer should start when `Isum > 2A`.
+
+### The Three Formulas (after phase switch to 1ph)
+
+| Formula | 1 EVSE | 2 EVSEs | 4 EVSEs | 8 EVSEs |
+|---------|--------|---------|---------|---------|
+| **Original (buggy)** | 2A | 8A | 20A | 44A |
+| **Upstream fix (02dafa2)** | 2A | 8A | 20A | 44A |
+| **Our fix (PR #119)** | 2A | 2A | 2A | 2A |
+
+Original and upstream give **identical results** after phase switch
+(Nr_Of_Phases_Charging=1 eliminates the only difference between them).
+
+---
+
+## Scenario: What the EVSE Sees
+
+All scenarios assume EnableC2=AUTO, car has already switched to 1 phase.
+Priority scheduling has paused all but 1 EVSE.
+The active EVSE draws 6A on 1 phase.
+
+### One EVSE plugged in
+
+| Isum (grid) | Meaning | Stop → Isum_after | Restart? | Original (2A) | Upstream (2A) | Ours (2A) |
+|---|---|---|---|---|---|---|
+| -5A | Exporting 5A | -11A | Yes | No ✓ | No ✓ | No ✓ |
+| -2A | Exporting 2A | -8A | Yes | No ✓ | No ✓ | No ✓ |
+| 0A | Balanced | -6A | Yes | No ✓ | No ✓ | No ✓ |
+| 1A | Importing 1A | -5A | Yes (-5<-4) | No ✓ | No ✓ | No ✓ |
+| 2A | Importing 2A | -4A | No (-4≥-4) | No ✓ | No ✓ | No ✓ |
+| 3A | Importing 3A | -3A | No | Yes ✓ | Yes ✓ | Yes ✓ |
+| 5A | Importing 5A | -1A | No | Yes ✓ | Yes ✓ | Yes ✓ |
+
+**All three formulas agree for 1 EVSE.** Threshold is 2A in all cases.
+
+### Two EVSEs plugged in (1 active after scheduling, 1 paused)
+
+The active EVSE still draws 6A. Isum is the same measurement.
+But `ActiveEVSE = 2` (counted before priority scheduling runs).
+
+| Isum (grid) | Stop → Isum_after | Restart? | Original (8A) | Upstream (8A) | Ours (2A) |
+|---|---|---|---|---|---|
+| 0A | -6A | Yes | No ✓ | No ✓ | No ✓ |
+| 1A | -5A | Yes | No ✓ | No ✓ | No ✓ |
+| 2A | -4A | No | No **✗** | No **✗** | No ✓ |
+| 3A | -3A | No | No **✗** | No **✗** | Yes ✓ |
+| 5A | -1A | No | No **✗** | No **✗** | Yes ✓ |
+| 7A | 1A | No | No **✗** | No **✗** | Yes ✓ |
+
+**At Isum=3A:** The grid is importing 3A. The EVSE draws 6A on 1 phase.
+Stopping would give Isum=-3A (export 3A). That's not enough to restart
+(need export > 4A). So stopping is final → timer should start.
+
+- **Ours (2A):** 3 > 2 → timer starts ✓
+- **Original/Upstream (8A):** 3 < 8 → timer doesn't start **✗**
+  The car keeps drawing 6A from the grid in "solar mode."
+
+**At Isum=7A:** Only 1A of the 6A draw is covered by solar. Grid supplies 7A.
+Stopping gives Isum=1A (still importing!). Obviously should stop.
+
+- **Ours (2A):** 7 > 2 → timer starts ✓
+- **Original/Upstream (8A):** 7 < 8 → timer STILL doesn't start **✗**
+
+### Four EVSEs plugged in (1 active, 3 paused)
+
+Same 6A draw, same Isum values. But `ActiveEVSE = 4`.
+
+| Isum (grid) | Restart? | **Original (20A)** | **Upstream (20A)** | **Ours (2A)** |
+|---|---|---|---|---|
+| 3A | No | No **✗** | No **✗** | Yes ✓ |
+| 5A | No | No **✗** | No **✗** | Yes ✓ |
+| 8A | No | No **✗** | No **✗** | Yes ✓ |
+
+With 4 EVSEs, Original and Upstream need Isum > 20A to fire. But one car
+on 1 phase + any house load can only produce ~8A of import. The timer
+**never fires**. The car charges from the grid indefinitely.
+
+### Eight EVSEs plugged in (1 active, 7 paused)
+
+| | Original | Upstream | Ours |
+|---|---|---|---|
+| Threshold | **44A** | **44A** | **2A** |
+| Max possible Isum (1 car, 1ph) | ~8A | ~8A | ~8A |
+| Timer ever fires? | **Never** | **Never** | Yes, at Isum > 2A |
+
+---
+
+## Fixed 3-Phase (EnableC2=NOT_PRESENT)
+
+When phase switching is not possible, the car stays on 3 phases (18A total).
+The SolarStopTimer fires with `Nr_Of_Phases_Charging = 3`.
+
+| Formula | 1 EVSE | 2 EVSEs |
+|---------|--------|---------|
+| **Original** | 14A | 32A |
+| **Upstream** | 2A | 8A |
+| **Ours** | 14A | 14A |
+
+Correct threshold for 3-phase: `18A - 4A = 14A`.
+
+| Isum | Stop → after | Restart? | Original 1EV (14A) | Upstream 1EV (2A) | Ours (14A) |
+|---|---|---|---|---|---|
+| 5A | -13A | Yes (-13<-4) | No ✓ | Yes **✗ cycling!** | No ✓ |
+| 10A | -8A | Yes (-8<-4) | No ✓ | Yes **✗ cycling!** | No ✓ |
+| 14A | -4A | No (-4≥-4) | No ✓ | Yes ✓ | No ✓ |
+| 15A | -3A | No | Yes ✓ | Yes ✓ | Yes ✓ |
+
+**Upstream at Isum=5A (fixed 3ph):** Timer starts (5>2). Car stops.
+Isum drops to -13A (exporting 13A). Restart condition: -13 < -4 → YES.
+Car immediately restarts. Isum rises back. Timer starts again.
+**Stop/start cycling.**
+
+---
+
+## Priority Scheduling + Rotation
+
+When solar is enough for 1 car but not all:
+
+```
+ 3 EVSEs, all 1-phase after switch. Isum hovers around 0A.
+
+ Time     Active    Isum    Other EVSEs      SolarStopTimer
+ ──────   ──────    ────    ──────────────   ──────────────
+ 0:00     EVSE #1   ~0A     #2,#3 NO_SUN     No (0<2)
+ 0:30     EVSE #2   ~0A     #1,#3 NO_SUN     No (rotation)
+ 1:00     EVSE #3   ~0A     #1,#2 NO_SUN     No (rotation)
+```
+
+Timer doesn't start because Isum ≈ 0A (solar covers the single car).
+Rotation gives each car fair charging time. All correct.
+
+When solar drops further (Isum rises above 2A persistently):
+
+```
+ 3 EVSEs, 1-phase. Isum = 4A (grid importing).
+
+ Time     Active    Isum    SolarStopTimer (ours, 2A)
+ ──────   ──────    ────    ──────────────────────────
+ 0:00     EVSE #1   4A      STARTS (4>2) → 10 min countdown
+ ...
+ 10:00    —         —       EXPIRES → LESS_6A → all stop
+```
+
+Correct: grid is importing 4A, stopping gives Isum=-2A, restart blocked
+(-2 ≥ -4). So stopping is permanent — timer was right to fire.
+
+---
+
+## Summary
+
+| Configuration | Correct threshold | Original | Upstream | Ours |
+|---|---|---|---|---|
+| 1 EVSE, 1 phase | 2A | 2A ✓ | 2A ✓ | 2A ✓ |
+| 2 EVSEs, 1 phase | 2A | 8A **✗** | 8A **✗** | 2A ✓ |
+| 4 EVSEs, 1 phase | 2A | 20A **✗** | 20A **✗** | 2A ✓ |
+| 8 EVSEs, 1 phase | 2A | 44A **✗** | 44A **✗** | 2A ✓ |
+| 1 EVSE, fixed 3ph | 14A | 14A ✓ | 2A **✗ cycling** | 14A ✓ |
+| 2 EVSEs, fixed 3ph | 14A | 32A **✗** | 8A **✗ cycling** | 14A ✓ |
+
+**Our fix is the only one correct for all configurations** because:
+1. It uses `Nr_Of_Phases_Charging` → adapts to actual phase configuration (1ph=2A, 3ph=14A)
+2. It removes `ActiveEVSE` → constant threshold regardless of EVSE count
+3. Priority scheduling + rotation handles multi-node distribution separately
+
+**Upstream fix errors:**
+1. Removes phase awareness → causes stop/start cycling for fixed 3-phase
+2. Keeps ActiveEVSE → same scaling bug as original for multi-node
+
+### Recommendation
+
+Keep our fix (PR #119). Document as conscious divergence from upstream.

--- a/docs/upstream-sync/process.md
+++ b/docs/upstream-sync/process.md
@@ -1,0 +1,227 @@
+# Upstream Integration Process
+
+This document defines the workflow for analyzing and integrating upstream commits
+from `dingo35/SmartEVSE-3.5` (and other upstreams) into the `basmeerman` fork.
+
+## Why not cherry-pick?
+
+The fork has restructured the codebase significantly:
+
+- State machine extracted from `main.cpp` → `evse_state_machine.c` (pure C)
+- ~70 scattered globals → `evse_ctx_t` context struct
+- Direct hardware calls → HAL callbacks via `evse_bridge.cpp`
+- New pure C modules: `mqtt_parser.c`, `http_api.c`, `ocpp_logic.c`, etc.
+- Native test suite (50+ suites, 1,096+ tests)
+
+Cherry-picks almost never apply cleanly. Each upstream commit must be **understood
+and reimplemented** in the fork's architecture, with tests.
+
+---
+
+## Flow Overview
+
+```
+1. DISCOVER   → What's new upstream?
+2. TRIAGE     → Relevant? Already done? Conflicting?
+3. ANALYZE    → What does it change? Side effects? Fork mapping?
+4. IMPLEMENT  → Reimplement in fork architecture (SbE workflow)
+5. VERIFY     → Full quality pipeline (5-step verification)
+6. MERGE      → PR + CI + merge
+7. DOCUMENT   → Update sync state + upstream-differences.md
+```
+
+---
+
+## Agent Roles
+
+| Role | Responsibility | Skills needed |
+|------|---------------|---------------|
+| **Sync Scout** | Fetch upstream, list new commits, produce triage table | Git, GitHub API |
+| **Commit Analyst** | Read each commit, classify, map to fork files, assess risk | Deep codebase knowledge |
+| **Implementer** | Reimplement following SbE workflow (spec → test → code) | Specialist role per CLAUDE.md |
+| **Quality Guardian** | Review, run full verification, approve merge | Testing, builds, standards |
+
+Agents may combine roles. A single agent can Scout + Analyze. The Implementer
+should use the appropriate Specialist Role from CLAUDE.md (State Machine, Solar,
+Load Balancing, OCPP, etc.) based on the commit's domain.
+
+---
+
+## Step 1: DISCOVER
+
+**Agent: Sync Scout**
+
+```bash
+# Fetch latest upstream
+git fetch origin
+
+# Find the last sync point
+cat docs/upstream-sync/sync-state.md | grep "Last synced"
+
+# List unintegrated commits
+git log --oneline <last-sync-hash>..origin/master
+```
+
+**Output:** Update the triage table in `sync-state.md`.
+
+---
+
+## Step 2: TRIAGE
+
+**Agent: Commit Analyst**
+
+For each new commit, classify into one of:
+
+| Classification | Action | Priority |
+|---|---|---|
+| **Already done** | Skip — note which fork PR covers it | — |
+| **Docs / cosmetic** | Low priority, batch or skip | P4 |
+| **Bug fix — safety-critical** | Reimplement with tests immediately | P1 |
+| **Bug fix — non-safety** | Reimplement, normal priority | P2 |
+| **New feature — wanted** | Evaluate scope, schedule | P2-P3 |
+| **New feature — not wanted** | Skip, document why | — |
+| **Conflicts with fork** | Analyze carefully, may need alternative approach | P2 |
+
+**Decision criteria:**
+
+1. Does this fix a bug our users hit? → High priority
+2. Does this touch code we've extracted to pure C? → Needs careful reimplementation
+3. Does this conflict with our improvements? → May need alternative approach
+4. Is this a feature we want? → Evaluate scope vs benefit
+5. Does upstream have tests? → If not, we add them (SbE requirement)
+
+---
+
+## Step 3: ANALYZE
+
+**Agent: Commit Analyst**
+
+For each commit to integrate, produce an analysis in `docs/upstream-sync/commits/`:
+
+```markdown
+## Upstream Commit: <hash> — <title>
+
+### Summary
+<1-2 sentence description of what it does and why>
+
+### Upstream changes
+- **Files:** <list>
+- **Key diff:** <essential code changes, abbreviated>
+
+### Fork mapping
+| Upstream file:line | Fork file:line | Notes |
+|---|---|---|
+| main.cpp:1234 | evse_state_machine.c:567 | State machine logic |
+| esp32.cpp:890 | esp32.cpp:890 | Glue code, same file |
+
+### Risk assessment
+- [ ] Safety-critical (state machine, contactors, current limiting)
+- [ ] Touches extracted pure C modules
+- [ ] Touches load balancing / multi-node
+- [ ] Touches OCPP
+- [ ] Requires new tests (no upstream test coverage)
+
+### Side effects
+<Interactions with fork-specific features: capacity tariff, multi-key validation,
+solar stability improvements, etc.>
+
+### Implementation approach
+<How to reimplement in fork architecture. Which Specialist Role applies.>
+```
+
+---
+
+## Step 4: IMPLEMENT
+
+**Agent: Implementer** (assigned Specialist Role per CLAUDE.md)
+
+Follow the project's SbE workflow strictly:
+
+1. **Read** — CLAUDE.md, CONTRIBUTING.md, relevant docs
+2. **Branch** — `upstream/<hash-short>-<description>`
+3. **Spec** — Write Given/When/Then scenarios
+4. **Test** — Create/extend test in `test/native/tests/`
+5. **Code** — Implement until tests pass
+6. **Verify** — Full 5-step verification:
+   ```bash
+   # 1. Native tests
+   cd SmartEVSE-3/test/native && make clean test
+   # 2. Sanitizers
+   make clean test CFLAGS_EXTRA="-fsanitize=address,undefined -fno-omit-frame-pointer"
+   # 3. Static analysis (cppcheck — full command from CLAUDE.md)
+   # 4. ESP32 build
+   pio run -e release -d SmartEVSE-3/
+   # 5. CH32 build
+   pio run -e ch32 -d SmartEVSE-3/
+   ```
+
+**Commit message format:**
+```
+upstream: <short description>
+
+Integrates upstream commit <full-hash> ("<upstream title>").
+
+<What was changed and why, in fork architecture terms>
+
+Upstream-Commit: <full-hash>
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+**Grouping:** Related upstream commits (e.g., two OCPP fixes in the same area) may
+be implemented in a single PR. Note all upstream commits in the commit message.
+
+---
+
+## Step 5: VERIFY
+
+**Agent: Quality Guardian**
+
+- All 5 verification steps pass
+- Regression tests for the affected area
+- No flash/RAM budget violations
+- `upstream-differences.md` updated if a difference narrowed or widened
+
+---
+
+## Step 6: MERGE
+
+Standard PR flow → CI green → merge → delete branch.
+
+---
+
+## Step 7: DOCUMENT
+
+Update `docs/upstream-sync/sync-state.md` with the new sync point and integration results.
+
+If the commit narrows an upstream difference (fork adopted upstream's approach) or
+widens one (fork took a different approach), update `docs/upstream-differences.md`.
+
+---
+
+## Multiple Upstreams
+
+The same flow works for any upstream. Add remotes:
+
+```bash
+git remote add stevens https://github.com/<user>/SmartEVSE-3.5.git
+git fetch stevens
+```
+
+The Sync Scout discovers from each remote independently. Triage deduplicates —
+if two upstreams have the same fix, only integrate once and note both sources.
+
+---
+
+## Automation
+
+| Task | Automatable? | Method |
+|---|---|---|
+| Discover new commits | Yes | `git fetch` + `git log` |
+| Triage (already done?) | Partially | Match commit messages against fork PRs |
+| Full analysis | No | Requires understanding intent |
+| Implementation | Partially | Agent drafts, human reviews safety-critical |
+| Verification | Yes | CI pipeline |
+| Sync state tracking | Yes | Markdown file updates |
+
+A scheduled agent (e.g., weekly) can run Step 1 and produce the triage table
+for human review before proceeding.

--- a/docs/upstream-sync/sync-state.md
+++ b/docs/upstream-sync/sync-state.md
@@ -14,7 +14,7 @@ Tracks integration status of upstream commits from `dingo35/SmartEVSE-3.5`.
 |---|------|------|--------|-------|---------------|----------|---------|-------|
 | 1 | `ecd088b` | 2026-03-29 | stegen | OCPP: recover from silent session loss (#345) | New feature | P2 | — | esp32.cpp + main.cpp, OCPP resilience |
 | 2 | `05c7fc2` | 2026-03-27 | stegen | OCPP: prevent actuator unlock/relock jitter | Bug fix — non-safety | P2 | — | esp32.cpp only, actuator control |
-| 3 | `02dafa2` | 2026-03-27 | stegen | Fix: Solar 1P stop timer | **Conflicts with fork** | P1 | — | Same bug as our PR #119 but different fix — see analysis below |
+| 3 | `02dafa2` | 2026-03-27 | stegen | Fix: Solar 1P stop timer | **Rejected** | P1 | #119 (alt) | Same bug as our PR #119; upstream's fix is incorrect — see analysis |
 | 4 | `190777f` | 2026-03-25 | stegen | Add OCPP firmware update functionality | New feature | P3 | — | esp32.cpp + network_common.h, 62 lines added |
 | 5 | `c0c6b16` | 2026-02-25 | hmmbob | Improve integrations section (#334) | Docs only | P4 | — | ESPHome configs, no firmware |
 
@@ -22,50 +22,35 @@ Tracks integration status of upstream commits from `dingo35/SmartEVSE-3.5`.
 
 ## Commit Analyses
 
-### #3: `02dafa2` — Fix: Solar 1P stop timer (CONFLICTS WITH FORK)
+### #3: `02dafa2` — Fix: Solar 1P stop timer (CONFLICTS WITH FORK — REJECTED)
 
 **Summary:** Upstream fixed the same SolarStopTimer threshold bug that our PR #119
-addressed. Both fixes target the same line but take different approaches.
+addressed, but with a different (and incorrect) approach.
 
-**Upstream fix:**
-```c
-// Before (buggy):
-Isum > (ActiveEVSE * MinCurrent * Nr_Of_Phases_Charging - StartCurrent) * 10
-// After (upstream fix):
-Isum > (ActiveEVSE * MinCurrent - StartCurrent) * 10
-```
-Upstream removed `Nr_Of_Phases_Charging`, reasoning that "Isum and StartCurrent
-are both sum-of-phases, so no phase multiplication needed."
+**Decision:** **Reject upstream change.** Keep PR #119. Documented as a conscious
+divergence in `docs/upstream-differences.md`.
 
-**Our fix (PR #119):**
-```c
-// After (our fix):
-Isum > (MinCurrent * Nr_Of_Phases_Charging - StartCurrent) * 10
-```
-We removed `ActiveEVSE`, reasoning that priority scheduling handles multi-node
-distribution and the timer should check single-EVSE viability.
+**Full analysis:** [analysis-02dafa2-solar-stop-threshold.md](analysis-02dafa2-solar-stop-threshold.md).
 
-**Comparison of thresholds** (6A min, 3-phase, StartCurrent=4, 2 EVSEs):
+**One-line rationale:** Upstream removed `Nr_Of_Phases_Charging` but kept
+`ActiveEVSE`. Our fix removed `ActiveEVSE` but kept `Nr_Of_Phases_Charging`.
+Working from the EVSE's actual perspective (it only sees `Isum` from the mains
+meter, not house/solar separately), and tracing the code path through phase
+switching, the upstream formula:
 
-| Fix | Formula | Threshold |
-|-----|---------|-----------|
-| Buggy (original) | (2 * 6 * 3 - 4) * 10 | 320 dA (32A) |
-| Upstream | (2 * 6 - 4) * 10 | 80 dA (8A) |
-| Our fork | (6 * 3 - 4) * 10 | 140 dA (14A) |
+- Reproduces the original `ActiveEVSE` scaling bug for multi-node setups (timer
+  threshold grows with node count and becomes unreachable)
+- Causes stop/start cycling for fixed 3-phase configurations (`EnableC2 != AUTO`),
+  because the threshold becomes 2A when the actual single-EVSE 3-phase draw is 18A
 
-**Analysis:** Both fixes make the threshold reachable. The upstream fix still scales
-with `ActiveEVSE` (80 for 2 EVSEs, 200 for 4) while ours is constant (140).
+Our formula adapts correctly via `Nr_Of_Phases_Charging` (which is set by the
+phase-switch logic that runs *before* SolarStopTimer fires) and is constant
+regardless of node count.
 
-The upstream approach is arguably more aggressive (lower threshold = stops sooner)
-but reintroduces the `ActiveEVSE` scaling problem at high node counts. With 8 EVSEs:
-upstream = (8*6-4)*10 = 440, ours = 140.
-
-**Decision:** Keep our fix (PR #119). It is more correct for large multi-node setups
-and was thoroughly tested (24 tests). Note this as a conscious divergence.
-
-**Additional upstream change:** `static uint8_t Broadcast = 1` → `= 4`. This is a
-separate timing fix (broadcast settings more frequently on startup). Should be
-evaluated independently.
+**Sub-change in same upstream commit:** `static uint8_t Broadcast = 1` → `= 4` in
+`timer1s_modbus_broadcast()`. Delays the first Modbus broadcast from ~1s to ~4s
+after boot (one-shot init delay). Low value, low risk. Tracked as **P4** —
+evaluate independently if/when we touch Modbus init timing.
 
 ### #1: `ecd088b` — OCPP: recover from silent session loss
 
@@ -110,8 +95,8 @@ Documentation only, no firmware changes.
 
 ## Next Actions
 
-1. [ ] **#3 (Solar 1P):** Mark as conscious divergence in upstream-differences.md.
-        Evaluate the `Broadcast = 4` sub-change separately.
+1. [x] **#3 (Solar 1P):** Rejected. Documented as conscious divergence in
+        `upstream-differences.md`. `Broadcast = 4` sub-change deferred (P4).
 2. [ ] **#1 + #2 (OCPP):** Bundle and implement — OCPP Specialist.
 3. [ ] **#4 (OCPP FW update):** Evaluate interaction with multi-key validation.
 4. [ ] **#5 (Docs):** Skip.

--- a/docs/upstream-sync/sync-state.md
+++ b/docs/upstream-sync/sync-state.md
@@ -1,0 +1,117 @@
+# Upstream Sync State
+
+Tracks integration status of upstream commits from `dingo35/SmartEVSE-3.5`.
+
+**Last synced to:** `40e78a2` (2026-02-25, merged via PR #123 base)
+**Current upstream HEAD:** `ecd088b` (2026-03-29)
+**Pending commits:** 5
+
+---
+
+## Sync: 2026-03-29 — Triage
+
+| # | Hash | Date | Author | Title | Classification | Priority | Fork PR | Notes |
+|---|------|------|--------|-------|---------------|----------|---------|-------|
+| 1 | `ecd088b` | 2026-03-29 | stegen | OCPP: recover from silent session loss (#345) | New feature | P2 | — | esp32.cpp + main.cpp, OCPP resilience |
+| 2 | `05c7fc2` | 2026-03-27 | stegen | OCPP: prevent actuator unlock/relock jitter | Bug fix — non-safety | P2 | — | esp32.cpp only, actuator control |
+| 3 | `02dafa2` | 2026-03-27 | stegen | Fix: Solar 1P stop timer | **Conflicts with fork** | P1 | — | Same bug as our PR #119 but different fix — see analysis below |
+| 4 | `190777f` | 2026-03-25 | stegen | Add OCPP firmware update functionality | New feature | P3 | — | esp32.cpp + network_common.h, 62 lines added |
+| 5 | `c0c6b16` | 2026-02-25 | hmmbob | Improve integrations section (#334) | Docs only | P4 | — | ESPHome configs, no firmware |
+
+---
+
+## Commit Analyses
+
+### #3: `02dafa2` — Fix: Solar 1P stop timer (CONFLICTS WITH FORK)
+
+**Summary:** Upstream fixed the same SolarStopTimer threshold bug that our PR #119
+addressed. Both fixes target the same line but take different approaches.
+
+**Upstream fix:**
+```c
+// Before (buggy):
+Isum > (ActiveEVSE * MinCurrent * Nr_Of_Phases_Charging - StartCurrent) * 10
+// After (upstream fix):
+Isum > (ActiveEVSE * MinCurrent - StartCurrent) * 10
+```
+Upstream removed `Nr_Of_Phases_Charging`, reasoning that "Isum and StartCurrent
+are both sum-of-phases, so no phase multiplication needed."
+
+**Our fix (PR #119):**
+```c
+// After (our fix):
+Isum > (MinCurrent * Nr_Of_Phases_Charging - StartCurrent) * 10
+```
+We removed `ActiveEVSE`, reasoning that priority scheduling handles multi-node
+distribution and the timer should check single-EVSE viability.
+
+**Comparison of thresholds** (6A min, 3-phase, StartCurrent=4, 2 EVSEs):
+
+| Fix | Formula | Threshold |
+|-----|---------|-----------|
+| Buggy (original) | (2 * 6 * 3 - 4) * 10 | 320 dA (32A) |
+| Upstream | (2 * 6 - 4) * 10 | 80 dA (8A) |
+| Our fork | (6 * 3 - 4) * 10 | 140 dA (14A) |
+
+**Analysis:** Both fixes make the threshold reachable. The upstream fix still scales
+with `ActiveEVSE` (80 for 2 EVSEs, 200 for 4) while ours is constant (140).
+
+The upstream approach is arguably more aggressive (lower threshold = stops sooner)
+but reintroduces the `ActiveEVSE` scaling problem at high node counts. With 8 EVSEs:
+upstream = (8*6-4)*10 = 440, ours = 140.
+
+**Decision:** Keep our fix (PR #119). It is more correct for large multi-node setups
+and was thoroughly tested (24 tests). Note this as a conscious divergence.
+
+**Additional upstream change:** `static uint8_t Broadcast = 1` → `= 4`. This is a
+separate timing fix (broadcast settings more frequently on startup). Should be
+evaluated independently.
+
+### #1: `ecd088b` — OCPP: recover from silent session loss
+
+**Summary:** Detects when an OCPP backend silently drops a transaction (no
+StopTransaction response) and recovers by ending the local session.
+
+**Files:** esp32.cpp (32 lines), main.cpp (2 lines)
+**Fork mapping:** esp32.cpp is firmware glue (same file in fork). The 2 lines in
+main.cpp may need to go in the bridge or state machine depending on what they do.
+**Risk:** Non-safety, OCPP-only. Low regression risk.
+**Action:** Implement — OCPP Specialist role.
+
+### #2: `05c7fc2` — OCPP: prevent actuator unlock/relock jitter
+
+**Summary:** Prevents the cable lock actuator from rapidly cycling when OCPP
+authorization state changes during an active charge session.
+
+**Files:** esp32.cpp (5 lines changed)
+**Fork mapping:** Same file, firmware glue.
+**Risk:** Non-safety but affects physical actuator. Low regression risk.
+**Action:** Implement — OCPP Specialist role. Can bundle with #1.
+
+### #4: `190777f` — Add OCPP firmware update functionality
+
+**Summary:** Allows OCPP backend to trigger firmware updates via the OCPP
+FirmwareUpdate message. Adds download + flash logic triggered by OCPP.
+
+**Files:** esp32.cpp (60 lines), network_common.h (2 lines)
+**Fork mapping:** esp32.cpp, may interact with firmware_manager.cpp.
+**Risk:** Interacts with OTA update (firmware_manager). Must verify it works
+with multi-key validation. Medium risk.
+**Action:** Evaluate — may need adaptation for multi-key signing.
+
+### #5: `c0c6b16` — Improve integrations section
+
+**Summary:** Adds ESPHome YAML configurations for various smart meter modules.
+Documentation only, no firmware changes.
+
+**Action:** Skip — integrations/ directory is not fork-specific.
+
+---
+
+## Next Actions
+
+1. [ ] **#3 (Solar 1P):** Mark as conscious divergence in upstream-differences.md.
+        Evaluate the `Broadcast = 4` sub-change separately.
+2. [ ] **#1 + #2 (OCPP):** Bundle and implement — OCPP Specialist.
+3. [ ] **#4 (OCPP FW update):** Evaluate interaction with multi-key validation.
+4. [ ] **#5 (Docs):** Skip.


### PR DESCRIPTION
## Summary

- New `docs/upstream-sync/process.md`: defines the 7-step upstream integration workflow and agent roles
- New `docs/upstream-sync/sync-state.md`: initial triage of 5 pending upstream commits

## Key finding

Upstream commit `02dafa2` fixes the same SolarStopTimer bug as our PR #119 but with a different approach. Upstream removed `Nr_Of_Phases_Charging`, we removed `ActiveEVSE`. Our fix is more correct for large multi-node setups (constant threshold vs scaling). Marked as conscious divergence.

## Next actions (from triage)

1. OCPP session recovery + actuator jitter (bundle, P2)
2. OCPP firmware update (evaluate vs multi-key, P3)
3. Skip docs-only commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)