### PR TITLE
docs(upstream-sync): evaluate 190777f (OCPP firmware update) — defer

### DIFF
--- a/docs/upstream-sync/analysis-190777f-ocpp-firmware-update.md
+++ b/docs/upstream-sync/analysis-190777f-ocpp-firmware-update.md
@@ -1,0 +1,193 @@
+# Analysis: Upstream Commit 190777f — OCPP Firmware Update
+
+## Question
+
+Does upstream commit `190777f` ("Add OCPP firmware update functionality") need
+adaptation to work with the fork's multi-key signature validation (PR #125)?
+
+## TL;DR
+
+**No adaptation needed for the validation path.** Multi-key compatibility is
+transparent — the upstream commit calls `forceUpdate(fwUrl, /*validate=*/true)`,
+which the fork already routes through `validate_sig()`, which PR #125 made into
+a multi-key loop.
+
+There ARE other concerns (memory budget, concurrency, `shouldReboot` reuse)
+that should be addressed if/when we integrate. **Recommendation: P3 — adopt as
+a separate PR with on-device verification and a memory-budget review.**
+
+## What 190777f does
+
+Adds an OCPP-triggered firmware update path. When the CSMS sends an
+`UpdateFirmware.req` OCPP message, the charger downloads the URL provided by
+the CSMS, validates the signature, and reboots into the new image.
+
+Implementation (60 lines in `esp32.cpp`, 2 lines in `network_common.h`):
+
+1. Includes `<MicroOcpp/Model/FirmwareManagement/FirmwareService.h>`.
+2. In `ocppInit()`, after the existing OCPP setup, registers four MicroOcpp
+   callbacks via `getFirmwareService()`:
+   - `setOnDownload(location)` — spawned task: `forceUpdate(url, true)`
+   - `setDownloadStatusInput()` — returns Downloaded / DownloadFailed / NotDownloaded
+   - `setOnInstall(location)` — sets `shouldReboot = true`
+   - `setInstallationStatusInput()` — returns Installed if `shouldReboot`, else NotInstalled
+3. Uses a `static volatile int OcppFwStatus` to communicate between the
+   download FreeRTOS task and the OCPP status callback.
+4. Declares `forceUpdate()` and `downloadProgress` as externs in
+   `network_common.h`.
+
+## Compatibility audit against the fork
+
+| Requirement | Upstream uses | Fork has? | Notes |
+|---|---|---|---|
+| `forceUpdate(const char*, bool)` | yes | **yes** at `firmware_manager.cpp:243` | extracted from upstream as part of fork's modularization |
+| `validate=true` triggers signature check | yes | **yes** at `firmware_manager.cpp:380` (`validate_sig()`) | identical call site |
+| Signature validation accepts upstream-signed FW | required | **yes** | trusted_keys[0] is the upstream public key |
+| Signature validation accepts basmeerman-signed FW | not required | **bonus** | trusted_keys[1] is the fork's public key — fork-built firmware can be pushed via OCPP too |
+| `downloadProgress` global | yes | **yes** at `network_common.cpp:342` | identical semantics |
+| `shouldReboot` global | yes | **yes** at `network_common.cpp:323` | identical semantics |
+| MicroOcpp `getFirmwareService()` API | yes | **yes** at `MicroOcpp.h:356` | library version supports it |
+| MicroOcpp `setOnDownload` / `setOnInstall` / `setDownloadStatusInput` / `setInstallationStatusInput` | yes | **yes** at `FirmwareService.h:34` (class includes the setters) | library version supports it |
+
+**Validation path walkthrough:**
+
+```
+CSMS → UpdateFirmware.req → MicroOcpp FirmwareService
+  → onDownload(location) callback (190777f)
+    → strdup(url) + xTaskCreate
+      → forceUpdate(url, /*validate=*/true)        ← firmware_manager.cpp:243
+        → HTTP GET, malloc(SIGNATURE_LENGTH), readBytes(signature)
+        → Update.writeStream(*stream)
+        → validate_sig(_target_partition, signature, updateSize)
+          → Phase 1: hash partition (SPI flash reads)
+          → Phase 2: for each trusted_keys[k] in trusted_keys[]:    ← PR #125
+              parse → mbedtls_pk_verify(hash, signature)
+              if ret==0: verified=true
+          → return verified
+        → if verified: esp_ota_set_boot_partition(_target_partition)
+```
+
+The multi-key loop is invisible to 190777f — any signature accepted by any
+trusted key is accepted by `validate_sig()`. Upstream-signed and fork-signed
+firmware both work via OCPP push.
+
+## Concerns NOT related to multi-key
+
+These are not blockers but should be addressed before merging an adapted
+version of 190777f. None of them touch the signature validation.
+
+### 1. Stack-size budget (CLAUDE.md HARD RULE)
+
+> Do not add FreeRTOS task creation or stack allocation without checking the
+> memory budget and documenting stack size rationale.
+
+Upstream creates a 4096-byte task (`xTaskCreate("OcppFwUpdate", 4096, ...)`).
+4096 bytes is plausible for an HTTPS download path that uses TLS, but the
+fork's web-UI firmware update task (in `network_common.cpp` near the
+`FirmwareUpdate` function) should be checked for the same stack size as a
+sanity reference. **Action:** confirm stack size matches the existing OTA
+update task and document the rationale in the integration commit.
+
+### 2. `OcppFwStatus` race
+
+```c
+static volatile int OcppFwStatus; // 0=idle, 1=downloading, 2=downloaded ok, -1=download failed
+```
+
+Written from the download task, read from the OCPP loop task. `volatile int`
+on a 32-bit aligned `int` is atomic on ESP32 (Xtensa) in practice, but the
+fork's coding standards prefer explicit synchronization for cross-task state.
+**Action:** either keep as-is and document the rationale, or wrap with the
+existing `evse_bridge` spinlock for consistency.
+
+### 3. `shouldReboot` is shared with other paths
+
+The upstream code reads `shouldReboot` as the "installation done" signal:
+
+```c
+fwService->setInstallationStatusInput([] () -> MicroOcpp::InstallationStatus {
+    if (shouldReboot) {
+        return MicroOcpp::InstallationStatus::Installed;
+    }
+    return MicroOcpp::InstallationStatus::NotInstalled;
+});
+```
+
+But `shouldReboot` is also set by web-UI update completion, settings save,
+factory reset, etc. (see `network_common.cpp:1488, 1519, 1667, 1733`). If a
+user triggers a web-UI update while an OCPP install is in flight, the OCPP
+status callback could report `Installed` for the OCPP transaction even though
+the OCPP install never actually ran. Edge case but worth noting.
+
+**Action:** consider a dedicated `OcppFwInstalled` flag set only by the OCPP
+install handler.
+
+### 4. Concurrent update guard
+
+Upstream guards against concurrent updates with:
+
+```c
+if (downloadProgress > 0) {
+    _LOG_A("OCPP FW: rejected, another update is in progress\n");
+    return false;
+}
+```
+
+This races against the web-UI update path that also writes `downloadProgress`.
+Acceptable for a basic guard but not airtight. **Action:** verify the web-UI
+update does the same check before starting.
+
+### 5. Pure C extraction (fork philosophy)
+
+Per CLAUDE.md, the fork prefers extracting decision logic to pure C for unit
+testing. The 60 lines in 190777f are mostly MicroOcpp callback registration
+and FreeRTOS task creation — there isn't much pure decision logic to extract.
+The "should we accept this update request" check is one boolean. Probably not
+worth a pure C extraction. **Action:** add a small unit test for the
+"reject if downloadProgress > 0" guard if a pure helper is introduced.
+
+## Testability constraints
+
+Unlike `ocpp_silence_decide()` and `ocpp_should_force_lock()`, this commit is
+mostly side effects (HTTP, MicroOcpp callbacks, FreeRTOS tasks, partition I/O).
+Native unit testing is limited to:
+
+- The "concurrent update rejection" guard (1 test)
+- The status mapping `OcppFwStatus → MicroOcpp::DownloadStatus` (3 tests)
+
+End-to-end verification requires:
+
+- A real or mock CSMS that supports the OCPP 1.6 `UpdateFirmware.req` message
+  → could use the fork's existing OCPP compatibility test infrastructure
+  (Plan 11 — `test/ocpp/`)
+- A signed firmware image hosted somewhere reachable by the charger
+- A second charger or rollback path in case the update fails
+
+## Recommendation
+
+**Adopt as P3, separate PR.**
+
+- The validation path is fully compatible with the fork's multi-key design.
+- The remaining concerns are quality polishes, not blockers.
+- It's a useful feature for fleets managed via OCPP CSMS.
+- It does not conflict with any other pending integration work.
+
+**Pre-integration checklist:**
+
+1. [ ] Confirm `xTaskCreate` stack size matches existing OTA update task
+2. [ ] Decide on synchronization for `OcppFwStatus` (keep volatile or wrap)
+3. [ ] Decide on `shouldReboot` reuse vs dedicated OCPP install flag
+4. [ ] Add small unit tests for the guard and status mapping (if extracted)
+5. [ ] Add an OCPP compatibility test that exercises `UpdateFirmware.req`
+      end-to-end against the mock CSMS in `test/ocpp/`
+6. [ ] On-device test: push fork-signed firmware via OCPP, observe accept
+7. [ ] On-device test: push upstream-signed firmware via OCPP, observe accept
+8. [ ] On-device test: push unsigned firmware via OCPP, observe reject
+9. [ ] On-device test: push corrupted-signature firmware via OCPP, observe reject
+10. [ ] Memory budget check after integration (`pio run -e release`)
+
+## Decision
+
+**Defer to a future PR.** No code changes needed in the current OCPP
+resilience integration (PR #130). Mark as P3 in `sync-state.md` — needs
+separate cycle with on-device verification.

--- a/docs/upstream-sync/sync-state.md
+++ b/docs/upstream-sync/sync-state.md
@@ -4,7 +4,7 @@ Tracks integration status of upstream commits from `dingo35/SmartEVSE-3.5`.
 
 **Last synced to:** `40e78a2` (2026-02-25, merged via PR #123 base)
 **Current upstream HEAD:** `ecd088b` (2026-03-29)
-**Pending commits:** 2 (was 5; #1 + #2 integrated, #3 rejected)
+**Pending commits:** 0 open / 1 deferred (was 5; #1 + #2 integrated via PR #130, #3 rejected, #4 evaluated and deferred to a future P3 PR, #5 skipped)
 
 ---
 
@@ -15,7 +15,7 @@ Tracks integration status of upstream commits from `dingo35/SmartEVSE-3.5`.
 | 1 | `ecd088b` | 2026-03-29 | stegen | OCPP: recover from silent session loss (#345) | **Integrated** | P2 | (PR pending) | Logic extracted to `ocpp_silence_decide()` in ocpp_logic.c, 10 unit tests |
 | 2 | `05c7fc2` | 2026-03-27 | stegen | OCPP: prevent actuator unlock/relock jitter | **Integrated** | P2 | (PR pending) | Logic extracted to `ocpp_should_force_lock()` in ocpp_logic.c, 11 unit tests |
 | 3 | `02dafa2` | 2026-03-27 | stegen | Fix: Solar 1P stop timer | **Rejected** | P1 | #119 (alt) | Same bug as our PR #119; upstream's fix is incorrect — see analysis |
-| 4 | `190777f` | 2026-03-25 | stegen | Add OCPP firmware update functionality | New feature | P3 | — | esp32.cpp + network_common.h, 62 lines added |
+| 4 | `190777f` | 2026-03-25 | stegen | Add OCPP firmware update functionality | **Evaluated — adopt later** | P3 | — | Multi-key compatible (validation path unchanged); deferred to separate PR — see [analysis](analysis-190777f-ocpp-firmware-update.md) |
 | 5 | `c0c6b16` | 2026-02-25 | hmmbob | Improve integrations section (#334) | Docs only | P4 | — | ESPHome configs, no firmware |
 
 ---
@@ -91,16 +91,31 @@ atomicity and gaining exhaustive unit-test coverage.
 cppcheck, ESP32 release build, CH32 build) all green. Traceability spec
 regenerated.
 
-### #4: `190777f` — Add OCPP firmware update functionality
+### #4: `190777f` — Add OCPP firmware update functionality (EVALUATED — DEFER)
 
-**Summary:** Allows OCPP backend to trigger firmware updates via the OCPP
-FirmwareUpdate message. Adds download + flash logic triggered by OCPP.
+**Multi-key compatibility:** ✅ **fully compatible, no adaptation needed.**
+Upstream calls `forceUpdate(url, /*validate=*/true)` which the fork already
+routes through `validate_sig()` — and PR #125 made `validate_sig()` a
+multi-key loop. Both upstream-signed and fork-signed firmware can be pushed
+via OCPP without code changes.
 
-**Files:** esp32.cpp (60 lines), network_common.h (2 lines)
-**Fork mapping:** esp32.cpp, may interact with firmware_manager.cpp.
-**Risk:** Interacts with OTA update (firmware_manager). Must verify it works
-with multi-key validation. Medium risk.
-**Action:** Evaluate — may need adaptation for multi-key signing.
+**Other concerns** (not blockers, but should be addressed when integrating):
+
+1. **Stack budget** — upstream creates a 4096-byte FreeRTOS task; CLAUDE.md
+   requires a memory-budget check + rationale for new task creation.
+2. **`OcppFwStatus` race** — written by download task, read by OCPP loop
+   task; uses `volatile int` only. Acceptable on Xtensa but worth wrapping
+   for consistency.
+3. **`shouldReboot` reuse** — the install-status callback reads `shouldReboot`
+   which is also set by web-UI updates and other paths; could report
+   `Installed` for the OCPP transaction even when the OCPP install never ran.
+4. **Concurrent update guard** — races with web-UI update path on
+   `downloadProgress`.
+
+**Decision:** Defer to a separate P3 PR. Needs on-device CSMS verification
+(push fork-signed, upstream-signed, unsigned, and corrupted firmware).
+
+**Full analysis:** [analysis-190777f-ocpp-firmware-update.md](analysis-190777f-ocpp-firmware-update.md).
 
 ### #5: `c0c6b16` — Improve integrations section
 
@@ -116,6 +131,7 @@ Documentation only, no firmware changes.
 1. [x] **#3 (Solar 1P):** Rejected. Documented as conscious divergence in
         `upstream-differences.md`. `Broadcast = 4` sub-change deferred (P4).
 2. [x] **#1 + #2 (OCPP resilience):** Integrated as bundled fork PR with
-        pure C extraction and 21 unit tests.
-3. [ ] **#4 (OCPP FW update):** Evaluate interaction with multi-key validation.
-4. [ ] **#5 (Docs):** Skip.
+        pure C extraction and 21 unit tests (PR #130, merged).
+3. [x] **#4 (OCPP FW update):** Evaluated — multi-key compatible. Deferred to
+        separate P3 PR (needs on-device CSMS verification + memory budget review).
+4. [x] **#5 (Docs):** Skipped — ESPHome integrations dir not fork-specific.


### PR DESCRIPTION
## Summary

Records the multi-key compatibility evaluation of upstream commit [`190777f`](https://github.com/dingo35/SmartEVSE-3.5/commit/190777f).

**Verdict:** validation path is fully compatible. Defer to a separate P3 PR.

| Question | Answer |
|---|---|
| Does it need adaptation for multi-key signing? | **No** — `forceUpdate(url, true)` already routes through `validate_sig()`, which PR #125 made multi-key. |
| Can upstream-signed firmware be pushed via OCPP? | Yes — accepted via `trusted_keys[0]`. |
| Can fork-signed firmware be pushed via OCPP? | Yes — accepted via `trusted_keys[1]`. Bonus capability over upstream. |
| Are there other concerns? | Yes — see analysis (memory budget, race conditions, `shouldReboot` reuse). None are blockers. |
| Should we adopt now? | No — defer to separate P3 PR. Needs on-device CSMS verification first. |

## What this PR contains

- New file: `docs/upstream-sync/analysis-190777f-ocpp-firmware-update.md` — full evaluation, compatibility audit table, validation path walkthrough, integration checklist
- `docs/upstream-sync/sync-state.md` — mark commit #4 as Evaluated/Deferred, update analysis section, check off action items 3 and 4

This closes the upstream sync triage from PR #127. All 5 pending upstream commits are now classified:

| # | Commit | Status |
|---|---|---|
| 1 | `ecd088b` (silent session loss) | **Integrated** via PR #130 |
| 2 | `05c7fc2` (actuator jitter) | **Integrated** via PR #130 |
| 3 | `02dafa2` (Solar 1P stop timer) | **Rejected** — see analysis (incorrect upstream fix) |
| 4 | `190777f` (OCPP firmware update) | **Evaluated/Deferred** — this PR |
| 5 | `c0c6b16` (ESPHome docs) | **Skipped** — not fork-relevant |

## Test plan

- [x] Doc-only changes — no code touched
- [x] Compatibility audit verified by source inspection (`firmware_manager.cpp:243`, `:380`, `network_common.cpp:323/342`)
- [x] MicroOcpp library version supports `getFirmwareService()` API (confirmed in `.pio/libdeps/release/MicroOcpp/src/MicroOcpp.h:356`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)