### PR TITLE
upstream: fix cable disconnect not detected when switching to PAUSE (e6110b1, P1)

### DIFF
--- a/SmartEVSE-3/src/evse_bridge.cpp
+++ b/SmartEVSE-3/src/evse_bridge.cpp
@@ -202,6 +202,7 @@ static void hal_on_state_change(uint8_t old_state, uint8_t new_state) {
         case STATE_A:
 #ifdef SMARTEVSE_VERSION
             timerAlarmWrite(timerA, PWM_100, true);
+            timerAlarmEnable(timerA);                                   // Re-enable in case STATE_B's single-shot (auto_reload=false) fired and disabled the alarm — otherwise CP sampling stops and cable disconnect in PAUSE is not detected (upstream e6110b1, fixes #347)
 #else
             TIM1->CH1CVR = 1000;
 #endif
@@ -244,6 +245,7 @@ static void hal_on_state_change(uint8_t old_state, uint8_t new_state) {
         case STATE_C1:
 #ifdef SMARTEVSE_VERSION
             timerAlarmWrite(timerA, PWM_100, true);
+            timerAlarmEnable(timerA);                                   // See STATE_A note (upstream e6110b1)
 #else
             TIM1->CH1CVR = 1000;
 #endif


### PR DESCRIPTION
## Summary

Integrates upstream [`e6110b1`](https://github.com/dingo35/SmartEVSE-3.5/commit/e6110b1) ("Fix cable disconnect not detected when switching to PAUSE", fixes upstream #347).

**Safety classification:** P1. Cable detect under PAUSE is safety-adjacent — undetected unplug leaves user state-machine inconsistent with physical connector state.

## Root cause

The CP sampling timer `timerA` is armed in three places in `evse_bridge.cpp`'s per-state platform actions — `STATE_A/B1`, `STATE_B`, and `STATE_C1`. The `STATE_B` path uses `auto_reload=false` (single-shot) because the 5%-duty sampling only needs to fire once per CP pulse.

When the alarm fires once in `STATE_B` and auto-disables itself, a later transition to `STATE_A` or `STATE_C1` calls `timerAlarmWrite(..., true)` — but **that call does NOT re-enable the alarm**, it only reconfigures it. The alarm stays disabled, the CP sampling ISR never runs, and the ADC-based cable-detect logic cannot observe voltage changes → cable unplugs aren't detected while the EVSE is paused.

## Fix

Add `timerAlarmEnable(timerA)` after each `timerAlarmWrite` in the two `STATE_A/B1` and `STATE_C1` branches. Matches upstream verbatim; only the **location** differs (fork has these writes in `evse_bridge.cpp` rather than `main.cpp`'s `setState()`, due to the fork's state-machine extraction).

| Upstream site | Fork site |
|---|---|
| `main.cpp:823` (STATE_A branch) | `evse_bridge.cpp:204-206` |
| `main.cpp:917` (STATE_C1 branch) | `evse_bridge.cpp:247-249` |

## Diff size

2 lines added. Diff is pure glue-layer platform code behind `#ifdef SMARTEVSE_VERSION`; the pure C state machine (`evse_state_machine.c`) is untouched.

## Verification

Full 5-step pre-push pipeline, all green:

| # | Step | Result |
|---|---|---|
| 1 | Native tests (51 suites) | pass |
| 2 | ASan + UBSan | pass |
| 3 | cppcheck | clean |
| 4 | ESP32 release build | SUCCESS (12s) |
| 5 | CH32 build | SUCCESS (3s) |

**No unit test added** — the change is in platform hardware-timer glue (`timerAlarmEnable` is an Arduino/ESP-IDF API). Outside the native-testable pure C surface by design. The pure C state machine is untouched.

## Test plan

- [x] Fork builds for both ESP32 and CH32
- [x] Existing 51 test suites still pass
- [ ] **On-device verification required (please run before merging):**
  - [ ] Plug vehicle (STATE_B), wait for charging to begin (STATE_C)
  - [ ] Manually pause via web/LCD (transition into STATE_B1 / STATE_A path)
  - [ ] Unplug vehicle while paused
  - [ ] Verify the charger detects unplug within the CP detection window (≤3s per IEC 61851-1) and returns to STATE_A
  - [ ] Repeat with OCPP-triggered pause if you use OCPP

🤖 Generated with [Claude Code](https://claude.com/claude-code)