### PR TITLE
upstream: OCPP public charging station LED scheme (3679fe3, P3)

### DIFF
--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -179,6 +179,7 @@ struct SettingsCache {
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION)
     uint8_t OcppMode;
 #endif
+    uint8_t LedMode;
     uint16_t CapacityLimit;
     bool valid;  // True once cache is populated from read_settings()
 };
@@ -1651,6 +1652,8 @@ void read_settings() {
         OcppMode = preferences.getUChar("OcppMode", OCPP_MODE);
 #endif //ENABLE_OCPP
 
+        LedMode = preferences.getUChar("LedMode", 0);
+
         CapacityLimit = preferences.getUShort("CapacityLim", 0);
         // Restore monthly peak from NVS
         CapacityState.monthly.monthly_peak_w = preferences.getInt("CapPeak", 0);
@@ -1721,6 +1724,7 @@ void read_settings() {
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION)
         settingsCache.OcppMode = OcppMode;
 #endif
+        settingsCache.LedMode = LedMode;
         settingsCache.CapacityLimit = CapacityLimit;
         settingsCache.valid = true;
         _LOG_D("Settings cache populated from NVS\n");
@@ -1807,6 +1811,8 @@ void write_settings(void) {
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION) //run OCPP only on ESP32
     PREFS_PUT_UCHAR_IF_CHANGED("OcppMode", OcppMode, OcppMode);
 #endif //ENABLE_OCPP
+
+    PREFS_PUT_UCHAR_IF_CHANGED("LedMode", LedMode, LedMode);
 
     PREFS_PUT_USHORT_IF_CHANGED("CapacityLim", CapacityLimit, CapacityLimit);
     // Persist monthly peak across reboots

--- a/SmartEVSE-3/src/esp32.h
+++ b/SmartEVSE-3/src/esp32.h
@@ -130,6 +130,7 @@ extern uint16_t SolarStopTimer;
 extern uint16_t MaxSumMainsTimer;
 extern uint8_t RFIDstatus;
 extern uint8_t OcppMode;
+extern uint8_t LedMode;
 extern bool LocalTimeSet;
 extern uint32_t serialnr;
 extern String PairingPin;

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -429,6 +429,7 @@ void GLCDHelp(void)                                                             
         case MENU_ROTATION:     desc = "Rotation interval in minutes (0=off)"; break;
         case MENU_IDLE_TIMEOUT: desc = "Idle timeout in seconds (anti-flap)"; break;
         case MENU_CAPLIMIT:     desc = "Capacity tariff 15-min peak limit (kW)"; break;
+        case MENU_LEDMODE:      desc = "LED color scheme (Standard / Public)";   break;
         default:                desc = (LCDNav < MENU_EXIT) ? MenuStr[LCDNav].Desc : ""; break;
     }
     unsigned int x = strlen(desc);
@@ -1135,6 +1136,8 @@ const char * getMenuItemOption(uint8_t nav) {
                 snprintf(Str, sizeof(Str), "%u.%u kW", value / 10, value % 10);
                 return Str;
             } else return StrDisabled;
+        case MENU_LEDMODE:
+            return value ? "Public" : "Standard";
         case MENU_EXIT:
             return StrExitMenu;
         default:
@@ -1229,6 +1232,7 @@ uint8_t getMenuItems (void) {
         MenuItems[m++] = MENU_IDLE_TIMEOUT;
     }
     MenuItems[m++] = MENU_LCDPIN;
+    MenuItems[m++] = MENU_LEDMODE;                                              // LED color scheme (0:Standard / 1:Public)
     MenuItems[m++] = MENU_EXIT;
 
     return m;
@@ -1371,6 +1375,10 @@ void GLCDMenu(uint8_t Buttons) {
                         value = MenuNavInt(Buttons, value, 0, 250);
                         setItemValue(LCDNav, value);
                         break;
+                    case MENU_LEDMODE:
+                        value = MenuNavInt(Buttons, value, 0, 1);
+                        setItemValue(LCDNav, value);
+                        break;
                     default:
                         value = MenuNavInt(Buttons, value, MenuStr[LCDNav].Min, MenuStr[LCDNav].Max);
                         setItemValue(LCDNav, value);
@@ -1445,6 +1453,7 @@ void GLCDMenu(uint8_t Buttons) {
                         case MENU_ROTATION:     lcdLabel = "ROTATION"; break;
                         case MENU_IDLE_TIMEOUT: lcdLabel = "IDLE TMO"; break;
                         case MENU_CAPLIMIT:     lcdLabel = "CAP PEAK"; break;
+                        case MENU_LEDMODE:      lcdLabel = "LED MODE"; break;
                         default:                lcdLabel = (LCDNav < MENU_EXIT) ? MenuStr[LCDNav].LCD : ""; break;
                     }
                     GLCD_print_menu(2, lcdLabel);                                           // add navigation arrows on both sides

--- a/SmartEVSE-3/src/http_handlers.cpp
+++ b/SmartEVSE-3/src/http_handlers.cpp
@@ -239,6 +239,7 @@ bool handle_URI(struct mg_connection *c, struct mg_http_message *hm,  webServerR
         doc["settings"]["lcdlock"] = LCDlock;
         doc["settings"]["lock"] = Lock;
         doc["settings"]["cablelock"] = CableLock;
+        doc["settings"]["ledmode"] = LedMode;
         doc["settings"]["prio_strategy"] = PrioStrategy;
         doc["settings"]["rotation_interval"] = RotationInterval;
         doc["settings"]["idle_timeout"] = IdleTimeout;

--- a/SmartEVSE-3/src/led_color.c
+++ b/SmartEVSE-3/src/led_color.c
@@ -152,3 +152,68 @@ led_rgb_t led_compute_color(const led_state_t *state, led_context_t *ctx) {
 
     return rgb;
 }
+
+/* ---- Public charging station scheme (upstream commit 3679fe3) ---- */
+
+led_rgb_t led_public_compute(const led_public_state_t *state,
+                             led_context_t *ctx) {
+    led_rgb_t rgb = {0, 0, 0};
+
+    /* Decision tree mirrors upstream main.cpp Public block. Order matters —
+     * flashes for recent events win over steady-state indicators. */
+
+    if (state->rfid_read_flash) {
+        /* Grey flash — RFID read in progress */
+        rgb.r = 128; rgb.g = 128; rgb.b = 128;
+    } else if (state->tx_authorized_flash) {
+        /* Green flash — authorization granted */
+        rgb.r = 0; rgb.g = 255; rgb.b = 0;
+    } else if (state->tx_rejected_flash) {
+        /* Red flash — authorization rejected */
+        rgb.r = 255; rgb.g = 0; rgb.b = 0;
+    } else if (state->tx_timeout_flash) {
+        /* Red flash — auth/connection timeout */
+        rgb.r = 255; rgb.g = 0; rgb.b = 0;
+    } else if (state->cp_status == LED_CP_STATUS_RESERVED) {
+        /* Orange — reserved */
+        rgb.r = 255; rgb.g = 128; rgb.b = 0;
+    } else if (state->cp_status == LED_CP_STATUS_UNAVAILABLE ||
+               state->cp_status == LED_CP_STATUS_FAULTED) {
+        /* Red — unavailable / faulted */
+        rgb.r = 255; rgb.g = 0; rgb.b = 0;
+    } else if (state->error_flags || state->charge_delay) {
+        /* Slow orange blink — waiting for power / delayed */
+        ctx->led_count += 2;
+        if (ctx->led_count > 230)
+            ctx->led_pwm = WAITING_LED_BRIGHTNESS;
+        else
+            ctx->led_pwm = 0;
+        rgb.r = ctx->led_pwm;
+        rgb.g = ctx->led_pwm / 2;
+        rgb.b = 0;
+    } else if (state->state == STATE_A) {
+        /* Green (dim) — Available */
+        ctx->led_pwm = STATE_A_LED_BRIGHTNESS;
+        rgb.r = 0;
+        rgb.g = ctx->led_pwm;
+        rgb.b = 0;
+    } else if (state->state == STATE_B || state->state == STATE_B1 ||
+               state->state == STATE_MODEM_REQUEST || state->state == STATE_MODEM_WAIT) {
+        /* Blue static — EV connected */
+        ctx->led_pwm = STATE_B_LED_BRIGHTNESS;
+        ctx->led_count = 128;  /* seed fade animation for the STATE_C transition */
+        rgb.r = 0;
+        rgb.g = 0;
+        rgb.b = ctx->led_pwm;
+    } else if (state->state == STATE_C) {
+        /* Blue fading — Charging */
+        ctx->led_count += 2;
+        ctx->led_pwm = led_ease8InOutQuad(led_triwave8(ctx->led_count));
+        rgb.r = 0;
+        rgb.g = 0;
+        rgb.b = ctx->led_pwm;
+    }
+    /* else: rgb stays {0,0,0} — nothing to display */
+
+    return rgb;
+}

--- a/SmartEVSE-3/src/led_color.h
+++ b/SmartEVSE-3/src/led_color.h
@@ -59,6 +59,48 @@ typedef struct {
  */
 led_rgb_t led_compute_color(const led_state_t *state, led_context_t *ctx);
 
+/* ---- Public charging station LED scheme (upstream commit 3679fe3) ---- */
+
+/*
+ * OCPP ChargePointStatus values the Public scheme cares about.
+ * Mirror of MicroOcpp::ChargePointStatus — caller converts.
+ */
+typedef enum {
+    LED_CP_STATUS_OTHER       = 0,  /* Any status we don't color specially */
+    LED_CP_STATUS_RESERVED    = 1,
+    LED_CP_STATUS_UNAVAILABLE = 2,
+    LED_CP_STATUS_FAULTED     = 3
+} led_cp_status_t;
+
+/*
+ * Snapshot for the Public scheme. Caller pre-computes timing booleans
+ * from millis() and MicroOcpp types so the pure function stays testable.
+ */
+typedef struct {
+    uint8_t  error_flags;        /* ErrorFlags */
+    uint8_t  charge_delay;       /* ChargeDelay */
+    uint8_t  state;              /* STATE_A / B / B1 / C / MODEM_* */
+
+    /* RFID-read grey flash: (millis() - OcppLastRfidUpdate) < 200 */
+    bool     rfid_read_flash;
+
+    /* Tx-notification flashes — caller pre-computes (age + enum check). */
+    bool     tx_authorized_flash;  /* < 1000ms && Authorized */
+    bool     tx_rejected_flash;    /* < 2000ms && {Rejected, DeAuthorized, ReservationConflict} */
+    bool     tx_timeout_flash;     /* <  300ms && {AuthorizationTimeout, ConnectionTimeout} */
+
+    /* ChargePointStatus (from getChargePointStatus()) */
+    led_cp_status_t cp_status;
+} led_public_state_t;
+
+/*
+ * Compute RGB for the Public (public charging station) scheme. Applied only
+ * when the LedMode setting is 1; callers keep using led_compute_color() for
+ * the Standard scheme otherwise. ctx persists across calls (animation).
+ */
+led_rgb_t led_public_compute(const led_public_state_t *state,
+                             led_context_t *ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/SmartEVSE-3/src/main.cpp
+++ b/SmartEVSE-3/src/main.cpp
@@ -280,6 +280,8 @@ uint8_t ColorSmart[3] = {0, 255, 0};    // Green
 uint8_t ColorSolar[3] = {255, 170, 0};    // Orange
 uint8_t ColorCustom[3] = {0, 0, 255};    // Blue
 
+uint8_t LedMode = 0;                    // LED color scheme: 0=Standard, 1=Public charging station (upstream 3679fe3)
+
 //#define FW_UPDATE_DELAY 30        //DINGO TODO                                            // time between detection of new version and actual update in seconds
 #define FW_UPDATE_DELAY 3600                                                    // time between detection of new version and actual update in seconds
 uint16_t firmwareUpdateTimer = 0;                                               // timer for firmware updates in seconds, max 0xffff = approx 18 hours
@@ -2157,7 +2159,37 @@ void BlinkLed_singlerun(void) {
     uint8_t RedPwm, GreenPwm, BluePwm;
 
 #if ENABLE_OCPP && defined(SMARTEVSE_VERSION) //run OCPP only on ESP32
-    // OCPP LED overrides (depend on millis() and MicroOcpp types, kept here)
+    if (LedMode) {
+        // Public charging station scheme (upstream 3679fe3).
+        // Pre-compute millis()/MicroOcpp-dependent booleans here, then call
+        // the pure C decision function so color mapping stays testable.
+        led_public_state_t pub;
+        memset(&pub, 0, sizeof(pub));
+        pub.error_flags  = ErrorFlags;
+        pub.charge_delay = ChargeDelay;
+        pub.state        = State;
+        unsigned long now = millis();
+        pub.rfid_read_flash     = (now - OcppLastRfidUpdate) < 200;
+        pub.tx_authorized_flash = (now - OcppLastTxNotification) < 1000 &&
+                                  OcppTrackTxNotification == MicroOcpp::TxNotification::Authorized;
+        pub.tx_rejected_flash   = (now - OcppLastTxNotification) < 2000 &&
+                                  (OcppTrackTxNotification == MicroOcpp::TxNotification::AuthorizationRejected ||
+                                   OcppTrackTxNotification == MicroOcpp::TxNotification::DeAuthorized ||
+                                   OcppTrackTxNotification == MicroOcpp::TxNotification::ReservationConflict);
+        pub.tx_timeout_flash    = (now - OcppLastTxNotification) < 300 &&
+                                  (OcppTrackTxNotification == MicroOcpp::TxNotification::AuthorizationTimeout ||
+                                   OcppTrackTxNotification == MicroOcpp::TxNotification::ConnectionTimeout);
+        switch (getChargePointStatus()) {
+            case ChargePointStatus_Reserved:    pub.cp_status = LED_CP_STATUS_RESERVED;    break;
+            case ChargePointStatus_Unavailable: pub.cp_status = LED_CP_STATUS_UNAVAILABLE; break;
+            case ChargePointStatus_Faulted:     pub.cp_status = LED_CP_STATUS_FAULTED;     break;
+            default:                            pub.cp_status = LED_CP_STATUS_OTHER;       break;
+        }
+        led_rgb_t rgb = led_public_compute(&pub, &ctx);
+        RedPwm = rgb.r; GreenPwm = rgb.g; BluePwm = rgb.b;
+    } else
+    // OCPP LED overrides for the Standard scheme (depend on millis() and
+    // MicroOcpp types, kept here). Only applied when LedMode == 0.
     if (OcppMode && (RFIDReader == 6 || RFIDReader == 0) &&
                 millis() - OcppLastRfidUpdate < 200) {
         RedPwm = 128; GreenPwm = 128; BluePwm = 128;
@@ -2420,7 +2452,7 @@ static void timer10ms_buttons(void) {
     }
 
     // Update/Show Helpmenu
-    if (LCDNav > MENU_ENTER && (LCDNav < MENU_EXIT || (LCDNav >= MENU_PRIO && LCDNav <= MENU_IDLE_TIMEOUT)) && (!SubMenu)) GLCDHelp();
+    if (LCDNav > MENU_ENTER && (LCDNav < MENU_EXIT || (LCDNav >= MENU_PRIO && LCDNav <= MENU_IDLE_TIMEOUT) || LCDNav == MENU_LEDMODE) && (!SubMenu)) GLCDHelp();
 
     if (timeinfo.tm_sec != old_sec) {
         old_sec = timeinfo.tm_sec;
@@ -2741,6 +2773,7 @@ uint8_t setItemValue(uint8_t nav, uint16_t val) {
         SETITEM(MENU_PRIO, PrioStrategy)
         SETITEM(MENU_ROTATION, RotationInterval)
         SETITEM(MENU_IDLE_TIMEOUT, IdleTimeout)
+        SETITEM(MENU_LEDMODE, LedMode)
         case MENU_CAPLIMIT:
             CapacityLimit = val * 100;
             capacity_set_limit(&CapacityState, (int32_t)CapacityLimit);
@@ -2911,6 +2944,8 @@ uint16_t getItemValue(uint8_t nav) {
             return IdleTimeout;
         case MENU_CAPLIMIT:
             return CapacityLimit / 100;
+        case MENU_LEDMODE:
+            return LedMode;
 
         // Status writeable
         case STATUS_STATE:

--- a/SmartEVSE-3/src/main.h
+++ b/SmartEVSE-3/src/main.h
@@ -304,6 +304,8 @@ void setPilot(bool On);
 
 #define MENU_STATE 50
 
+#define MENU_LEDMODE 51                                                         // LED color scheme (0:Standard / 1:Public charging station) — upstream 3679fe3
+
 class Button {
   public:
     void CheckSwitch(bool force = false);

--- a/SmartEVSE-3/test/native/tests/test_led_color.c
+++ b/SmartEVSE-3/test/native/tests/test_led_color.c
@@ -484,6 +484,277 @@ void test_state_b_custom_override(void) {
 }
 
 /* ================================================================
+ * Public charging station scheme (upstream commit 3679fe3)
+ * ================================================================ */
+
+static led_public_state_t make_public_default(void) {
+    led_public_state_t s;
+    memset(&s, 0, sizeof(s));
+    s.state = STATE_A;
+    s.cp_status = LED_CP_STATUS_OTHER;
+    return s;
+}
+
+/*
+ * @feature LED Color — Public Scheme
+ * @req REQ-LED-100
+ * @scenario RFID read grey flash wins over all other signals
+ * @given rfid_read_flash true, other flashes also asserted
+ * @when led_public_compute is called
+ * @then Returns grey (128,128,128) — highest priority in the decision tree
+ */
+void test_public_rfid_flash_priority(void) {
+    led_public_state_t s = make_public_default();
+    s.rfid_read_flash = true;
+    s.tx_authorized_flash = true;   /* should be ignored */
+    s.cp_status = LED_CP_STATUS_RESERVED;
+    led_context_t c = {0, 0};
+    led_rgb_t rgb = led_public_compute(&s, &c);
+    TEST_ASSERT_EQUAL_INT(128, rgb.r);
+    TEST_ASSERT_EQUAL_INT(128, rgb.g);
+    TEST_ASSERT_EQUAL_INT(128, rgb.b);
+}
+
+/*
+ * @feature LED Color — Public Scheme
+ * @req REQ-LED-100
+ * @scenario Authorized-grant green flash
+ * @given tx_authorized_flash true, no higher-priority signal
+ * @when led_public_compute is called
+ * @then Returns green (0,255,0)
+ */
+void test_public_tx_authorized_green(void) {
+    led_public_state_t s = make_public_default();
+    s.tx_authorized_flash = true;
+    led_context_t c = {0, 0};
+    led_rgb_t rgb = led_public_compute(&s, &c);
+    TEST_ASSERT_EQUAL_INT(0, rgb.r);
+    TEST_ASSERT_EQUAL_INT(255, rgb.g);
+    TEST_ASSERT_EQUAL_INT(0, rgb.b);
+}
+
+/*
+ * @feature LED Color — Public Scheme
+ * @req REQ-LED-100
+ * @scenario Authorization-rejected red flash
+ * @given tx_rejected_flash true
+ * @when led_public_compute is called
+ * @then Returns red (255,0,0)
+ */
+void test_public_tx_rejected_red(void) {
+    led_public_state_t s = make_public_default();
+    s.tx_rejected_flash = true;
+    led_context_t c = {0, 0};
+    led_rgb_t rgb = led_public_compute(&s, &c);
+    TEST_ASSERT_EQUAL_INT(255, rgb.r);
+    TEST_ASSERT_EQUAL_INT(0, rgb.g);
+    TEST_ASSERT_EQUAL_INT(0, rgb.b);
+}
+
+/*
+ * @feature LED Color — Public Scheme
+ * @req REQ-LED-100
+ * @scenario Auth-timeout red flash
+ * @given tx_timeout_flash true
+ * @when led_public_compute is called
+ * @then Returns red (255,0,0)
+ */
+void test_public_tx_timeout_red(void) {
+    led_public_state_t s = make_public_default();
+    s.tx_timeout_flash = true;
+    led_context_t c = {0, 0};
+    led_rgb_t rgb = led_public_compute(&s, &c);
+    TEST_ASSERT_EQUAL_INT(255, rgb.r);
+    TEST_ASSERT_EQUAL_INT(0, rgb.g);
+    TEST_ASSERT_EQUAL_INT(0, rgb.b);
+}
+
+/*
+ * @feature LED Color — Public Scheme
+ * @req REQ-LED-101
+ * @scenario Reserved ChargePoint status → orange
+ * @given cp_status = LED_CP_STATUS_RESERVED, no flashes
+ * @when led_public_compute is called
+ * @then Returns orange (255,128,0)
+ */
+void test_public_reserved_orange(void) {
+    led_public_state_t s = make_public_default();
+    s.cp_status = LED_CP_STATUS_RESERVED;
+    led_context_t c = {0, 0};
+    led_rgb_t rgb = led_public_compute(&s, &c);
+    TEST_ASSERT_EQUAL_INT(255, rgb.r);
+    TEST_ASSERT_EQUAL_INT(128, rgb.g);
+    TEST_ASSERT_EQUAL_INT(0, rgb.b);
+}
+
+/*
+ * @feature LED Color — Public Scheme
+ * @req REQ-LED-101
+ * @scenario Unavailable ChargePoint status → red
+ * @given cp_status = LED_CP_STATUS_UNAVAILABLE
+ * @when led_public_compute is called
+ * @then Returns red (255,0,0)
+ */
+void test_public_unavailable_red(void) {
+    led_public_state_t s = make_public_default();
+    s.cp_status = LED_CP_STATUS_UNAVAILABLE;
+    led_context_t c = {0, 0};
+    led_rgb_t rgb = led_public_compute(&s, &c);
+    TEST_ASSERT_EQUAL_INT(255, rgb.r);
+    TEST_ASSERT_EQUAL_INT(0, rgb.g);
+    TEST_ASSERT_EQUAL_INT(0, rgb.b);
+}
+
+/*
+ * @feature LED Color — Public Scheme
+ * @req REQ-LED-101
+ * @scenario Faulted ChargePoint status → red
+ * @given cp_status = LED_CP_STATUS_FAULTED
+ * @when led_public_compute is called
+ * @then Returns red (255,0,0)
+ */
+void test_public_faulted_red(void) {
+    led_public_state_t s = make_public_default();
+    s.cp_status = LED_CP_STATUS_FAULTED;
+    led_context_t c = {0, 0};
+    led_rgb_t rgb = led_public_compute(&s, &c);
+    TEST_ASSERT_EQUAL_INT(255, rgb.r);
+    TEST_ASSERT_EQUAL_INT(0, rgb.g);
+    TEST_ASSERT_EQUAL_INT(0, rgb.b);
+}
+
+/*
+ * @feature LED Color — Public Scheme
+ * @req REQ-LED-102
+ * @scenario Waiting / ChargeDelay → slow orange blink (bright phase)
+ * @given charge_delay set, led_count seeded past 230
+ * @when led_public_compute is called
+ * @then Returns orange at waiting brightness (R=WAITING_LED_BRIGHTNESS, G=R/2, B=0)
+ */
+void test_public_waiting_orange_bright(void) {
+    led_public_state_t s = make_public_default();
+    s.charge_delay = 30;
+    led_context_t c = {230, 0};  /* +2 inside fn crosses the 230 threshold */
+    led_rgb_t rgb = led_public_compute(&s, &c);
+    TEST_ASSERT_EQUAL_INT(WAITING_LED_BRIGHTNESS, rgb.r);
+    TEST_ASSERT_EQUAL_INT(WAITING_LED_BRIGHTNESS / 2, rgb.g);
+    TEST_ASSERT_EQUAL_INT(0, rgb.b);
+}
+
+/*
+ * @feature LED Color — Public Scheme
+ * @req REQ-LED-102
+ * @scenario Waiting / ChargeDelay → slow orange blink (dark phase)
+ * @given error flag set, led_count seeded so post-increment is <= 230
+ * @when led_public_compute is called
+ * @then Returns (0,0,0) — dark part of the blink
+ */
+void test_public_waiting_orange_dark(void) {
+    led_public_state_t s = make_public_default();
+    s.error_flags = CT_NOCOMM;
+    led_context_t c = {0, 0};
+    led_rgb_t rgb = led_public_compute(&s, &c);
+    TEST_ASSERT_EQUAL_INT(0, rgb.r);
+    TEST_ASSERT_EQUAL_INT(0, rgb.g);
+    TEST_ASSERT_EQUAL_INT(0, rgb.b);
+}
+
+/*
+ * @feature LED Color — Public Scheme
+ * @req REQ-LED-103
+ * @scenario STATE_A → green (dimmed) = Available
+ * @given state = STATE_A, no flashes, no waiting
+ * @when led_public_compute is called
+ * @then Returns (0, STATE_A_LED_BRIGHTNESS, 0)
+ */
+void test_public_state_a_green_dim(void) {
+    led_public_state_t s = make_public_default();
+    s.state = STATE_A;
+    led_context_t c = {0, 0};
+    led_rgb_t rgb = led_public_compute(&s, &c);
+    TEST_ASSERT_EQUAL_INT(0, rgb.r);
+    TEST_ASSERT_EQUAL_INT(STATE_A_LED_BRIGHTNESS, rgb.g);
+    TEST_ASSERT_EQUAL_INT(0, rgb.b);
+}
+
+/*
+ * @feature LED Color — Public Scheme
+ * @req REQ-LED-103
+ * @scenario STATE_B → blue static = EV connected
+ * @given state = STATE_B
+ * @when led_public_compute is called
+ * @then Returns (0, 0, STATE_B_LED_BRIGHTNESS) and seeds led_count=128
+ */
+void test_public_state_b_blue_static(void) {
+    led_public_state_t s = make_public_default();
+    s.state = STATE_B;
+    led_context_t c = {0, 0};
+    led_rgb_t rgb = led_public_compute(&s, &c);
+    TEST_ASSERT_EQUAL_INT(0, rgb.r);
+    TEST_ASSERT_EQUAL_INT(0, rgb.g);
+    TEST_ASSERT_EQUAL_INT(STATE_B_LED_BRIGHTNESS, rgb.b);
+    TEST_ASSERT_EQUAL_INT(128, c.led_count);  /* seeds fade animation */
+}
+
+/*
+ * @feature LED Color — Public Scheme
+ * @req REQ-LED-103
+ * @scenario STATE_B1 and STATE_MODEM_* also → blue static
+ * @given state = STATE_B1
+ * @when led_public_compute is called
+ * @then Returns (0, 0, STATE_B_LED_BRIGHTNESS)
+ */
+void test_public_state_b1_blue_static(void) {
+    led_public_state_t s = make_public_default();
+    s.state = STATE_B1;
+    led_context_t c = {0, 0};
+    led_rgb_t rgb = led_public_compute(&s, &c);
+    TEST_ASSERT_EQUAL_INT(STATE_B_LED_BRIGHTNESS, rgb.b);
+    TEST_ASSERT_EQUAL_INT(0, rgb.r);
+    TEST_ASSERT_EQUAL_INT(0, rgb.g);
+}
+
+/*
+ * @feature LED Color — Public Scheme
+ * @req REQ-LED-103
+ * @scenario STATE_C → blue fading (animation advances)
+ * @given state = STATE_C, led_count incremented across calls
+ * @when led_public_compute is called twice
+ * @then Both outputs have R=0, G=0, B>0 and led_count advances
+ */
+void test_public_state_c_blue_fading(void) {
+    led_public_state_t s = make_public_default();
+    s.state = STATE_C;
+    led_context_t c = {0, 0};
+    led_rgb_t rgb1 = led_public_compute(&s, &c);
+    uint8_t count_after_1 = c.led_count;
+    led_rgb_t rgb2 = led_public_compute(&s, &c);
+    TEST_ASSERT_EQUAL_INT(0, rgb1.r);
+    TEST_ASSERT_EQUAL_INT(0, rgb1.g);
+    TEST_ASSERT_EQUAL_INT(0, rgb2.r);
+    TEST_ASSERT_EQUAL_INT(0, rgb2.g);
+    TEST_ASSERT_TRUE(c.led_count > count_after_1);  /* count advanced */
+}
+
+/*
+ * @feature LED Color — Public Scheme
+ * @req REQ-LED-104
+ * @scenario Default/unknown state with no signals → all off
+ * @given Default snapshot, state is unknown value
+ * @when led_public_compute is called
+ * @then Returns (0,0,0) — falls off the decision tree
+ */
+void test_public_unknown_state_off(void) {
+    led_public_state_t s = make_public_default();
+    s.state = 99;  /* not any handled state */
+    led_context_t c = {0, 0};
+    led_rgb_t rgb = led_public_compute(&s, &c);
+    TEST_ASSERT_EQUAL_INT(0, rgb.r);
+    TEST_ASSERT_EQUAL_INT(0, rgb.g);
+    TEST_ASSERT_EQUAL_INT(0, rgb.b);
+}
+
+/* ================================================================
  * Main
  * ================================================================ */
 
@@ -518,6 +789,22 @@ int main(void) {
     /* Color modes */
     RUN_TEST(test_state_a_solar_color);
     RUN_TEST(test_state_b_custom_override);
+
+    /* Public scheme (upstream 3679fe3) */
+    RUN_TEST(test_public_rfid_flash_priority);
+    RUN_TEST(test_public_tx_authorized_green);
+    RUN_TEST(test_public_tx_rejected_red);
+    RUN_TEST(test_public_tx_timeout_red);
+    RUN_TEST(test_public_reserved_orange);
+    RUN_TEST(test_public_unavailable_red);
+    RUN_TEST(test_public_faulted_red);
+    RUN_TEST(test_public_waiting_orange_bright);
+    RUN_TEST(test_public_waiting_orange_dark);
+    RUN_TEST(test_public_state_a_green_dim);
+    RUN_TEST(test_public_state_b_blue_static);
+    RUN_TEST(test_public_state_b1_blue_static);
+    RUN_TEST(test_public_state_c_blue_fading);
+    RUN_TEST(test_public_unknown_state_off);
 
     TEST_SUITE_RESULTS();
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -291,6 +291,12 @@ Set the Function of an External Switch (Pin SW or Connector P2).
 - **Custom B**: A momentary push button can be used for external integrations.
 - **Custom S**: A toggle switch can be used for external integrations.
 
+## LED MODE
+Select the LED color scheme.
+
+- **Standard** — Default color scheme: green/smart-color for charging, orange for solar, red for errors. Custom colors can be set via MQTT.
+- **Public** — Public charging station scheme, OCPP-aware. Green (dim) = Available, Blue (static) = EV connected, Blue (fading) = Charging, Orange = Reserved, Red = Faulted / Unavailable. RFID read produces a short grey flash; authorization result produces a short green (granted) or red (rejected/timeout) flash. Best used with OCPP enabled.
+
 ## RCMON
 Residual Current Monitor (RCM14-03) plugged into connector P1.
 

--- a/docs/upstream-differences.md
+++ b/docs/upstream-differences.md
@@ -75,6 +75,7 @@ Addresses upstream issue
 | Atomic connector lock decision | Upstream `ocppLoop()` briefly flipped `OcppForcesLock` false→true within one iteration, causing actuator unlock/relock jitter — integrated upstream `05c7fc2` with the decision extracted to pure C and 11 unit tests | upstream `05c7fc2` |
 | OCPP Finishing-before-Available sequence | CSMS missed the Finishing state because OccupiedInput went false immediately after StopTx — integrated upstream `afd72a8` with the decision extracted to pure C (`ocpp_should_report_occupied`) and 6 unit tests | upstream `afd72a8` |
 | Cable disconnect detection under PAUSE | CP sampling timer left disabled after STATE_B single-shot fired — integrated upstream `e6110b1` (timerAlarmEnable in STATE_A/STATE_C1 paths) | upstream `e6110b1` |
+| Public charging station LED scheme | Public-charger color semantics (available/connected/charging/reserved/faulted) selectable via new `LedMode` menu — integrated upstream `3679fe3` with the decision tree extracted to pure C (`led_public_compute()`) and 14 unit tests. Fork keeps `MENU_LEDMODE=51` to avoid renumber cascade. | upstream `3679fe3` |
 
 ### MQTT & Home Assistant
 

--- a/docs/upstream-sync/sync-state.md
+++ b/docs/upstream-sync/sync-state.md
@@ -26,7 +26,7 @@ Prior sync window (2026-03-29, now closed): 2 integrated (PR #130), 1 rejected,
 | 9 | `3ab1cee` | 2026-04-08 | stegen | `main.cpp`: reset Node ChargeDelay countdown when solar power disappears | **Integrated** | P2 | (P2 bundle) | Applied in `processAllNodeStates()` master-side slave-node error tracking |
 | 10 | `a54b07f` | 2026-04-09 | stegen | `main.cpp`: prevent current fluctuations when CAPACITY is used (fixes #327) | **Integrated** | P2 | (P2 bundle) | Applied in pure C `evse_calc_balanced_current()`; 3 unit tests. `test_s9_maxsummains_limits` updated to use larger exceedance (Isum 350→600) so per-phase reduction crosses fork's SmartDeadBand — documents the gentler, correct per-phase semantics. |
 | 11 | `92d42eb` | 2026-04-10 | Juurlink | Refactor tooltips: centralize styles in `styling.css` + a11y (#301) | Web UI cosmetic | P4 | — | CSS-only. |
-| 12 | `3679fe3` | 2026-04-10 | stegen | OCPP: public charging station LED colour scheme when OCPP is enabled (#351) | New feature | P3 | — | 6 files, adds LedMode menu option. Fork has pure C `led_color.c`; need to adapt, not cherry-pick. |
+| 12 | `3679fe3` | 2026-04-10 | stegen | OCPP: public charging station LED colour scheme when OCPP is enabled (#351) | **Integrated** | P3 | (this PR) | Public scheme extracted to `led_public_compute()` in `led_color.c`; 14 unit tests. `MENU_LEDMODE=51` (fork avoids renumber cascade). |
 | 13 | `790f2a9` | 2026-04-10 | stegen | `docs`: update OCPP documentation | Docs only | P4 | — | Skip or cherry-pick docs bits. |
 
 ### Suggested batching


### PR DESCRIPTION
## Summary

Integrates upstream [`3679fe3`](https://github.com/dingo35/SmartEVSE-3.5/commit/3679fe3) (\"OCPP: public charging station LED colour scheme when OCPP is enabled\", #351).

Adds a new **LED MODE** setting (`0=Standard`, `1=Public`). In Public mode, the LED uses public-charger semantics per OCPP state.

| Public-scheme color | Meaning |
|---|---|
| Green (dim) | Available (STATE_A) |
| Blue (static) | EV connected (STATE_B / B1 / MODEM_*) |
| Blue (fading) | Charging (STATE_C) |
| Orange | Reserved |
| Red | Faulted / Unavailable |
| Orange blink | Waiting / ChargeDelay / error |
| Grey flash | RFID read in progress |
| Green flash | Authorization granted |
| Red flash | Authorization rejected / timeout |

## Architecture

Following the fork's pure-C-testability pattern: the decision tree is extracted to a new `led_public_compute()` function in `led_color.c`, mirroring the existing `led_compute_color()` pattern. Caller (`BlinkLed_singlerun` in `main.cpp`) pre-computes timing booleans from `millis()` and MicroOcpp enum checks, then invokes the pure function.

| Piece | Location |
|---|---|
| Pure C decision | `led_color.c` — `led_public_compute()` |
| Snapshot type | `led_color.h` — `led_public_state_t` + `led_cp_status_t` enum |
| Glue | `main.cpp` — `BlinkLed_singlerun()` branches on `LedMode` |
| Menu bits | `glcd.cpp` — desc / option / label / MenuItems / MenuNavInt |
| Persistence | `esp32.cpp` — settings cache + read/write NVS |
| REST API | `http_handlers.cpp` — `doc[\"settings\"][\"ledmode\"]` |
| User docs | `docs/configuration.md` |

## Menu enum (important)

Upstream assigns `MENU_LEDMODE=43`, shifting `MENU_OFF/ON/EXIT` to 44/45/46. That collides with the fork's `MENU_PRIO=46`, `MENU_ROTATION=47`, `MENU_IDLE_TIMEOUT=48`, `MENU_CAPLIMIT=49`, `MENU_STATE=50`. Cascading those +1 is risky (affects stored preferences and Modbus register layout).

**Chose `MENU_LEDMODE=51`** (past `MENU_STATE`) — no collisions, no cascade. The fork already handles `MENU_* > MENU_EXIT` through explicit switch cases (pre-existing pattern from `MENU_PRIO..MENU_CAPLIMIT`); same pattern applied here.

## Tests (REQ-LED-100..104)

**14 new tests** in `test_led_color.c` cover:

- Priority ordering — `rfid_read_flash` beats lower-priority signals
- Each flash independently (authorized / rejected / timeout)
- Each `cp_status` (Reserved / Unavailable / Faulted)
- Waiting orange blink (bright + dark phases)
- `STATE_A` green dim / `STATE_B` blue static + led_count seed / `STATE_B1` / `STATE_C` fade advance
- Unknown state → off

Total LED suite: **33 tests pass** (up from 19).

## Verification

Full 5-step pre-push pipeline, all green:

| # | Step | Result |
|---|---|---|
| 1 | Native tests (51 suites) | pass |
| 2 | ASan + UBSan | pass |
| 3 | cppcheck | clean |
| 4 | ESP32 release build | SUCCESS (10s) |
| 5 | CH32 build | SUCCESS (4s) |

## Test plan

- [x] Pure C decision tree exhaustively tested
- [x] ESP32 + CH32 firmware build
- [x] Existing 50 other native suites still pass
- [ ] **On-device:** configure OCPP, set `LED MODE = Public`, step through
  - [ ] Unplugged → green dim
  - [ ] Plug car → blue static
  - [ ] Start charging → blue fading
  - [ ] CSMS Reserve → orange
  - [ ] CSMS Unavailable / Faulted → red
  - [ ] RFID swipe → brief grey flash
  - [ ] Authorization granted → brief green flash
  - [ ] Authorization rejected → brief red flash
- [ ] **On-device:** set `LED MODE = Standard`, verify original behavior unchanged
- [ ] **On-device:** verify `LedMode` persists across reboot
- [ ] **On-device:** verify `/settings` REST returns `\"ledmode\"` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)