### PR TITLE
docs(upstream-sync): evaluate 2c015fb Raw Settings UI — defer to Plan 07

### DIFF
--- a/docs/upstream-sync/analysis-2c015fb-raw-settings-ui.md
+++ b/docs/upstream-sync/analysis-2c015fb-raw-settings-ui.md
@@ -1,0 +1,114 @@
+# Analysis: Upstream Commit 2c015fb — Raw Settings UI
+
+## Question
+
+Adopt upstream `2c015fb` ("Improved Raw Settings view with formatted JSON and
+Download button (#353)") now, or defer?
+
+## TL;DR
+
+**Defer to a future Plan 07 (Web UI Modernization) PR.** The change is a
+nice-to-have UX polish (in-page JSON viewer with syntax highlighting + download)
+that conflicts heavily with the fork's diverged dashboard and its own planned
+web UI redesign. The fork already has a working "Raw Data" link that opens the
+raw `/settings` JSON in the browser — no user-visible regression from deferring.
+
+## What 2c015fb does
+
+Adds an in-page raw settings viewer. The existing "Raw Data" link (currently
+href=`/settings`) is replaced with a link that loads the same dashboard with
+`?raw=1` in the URL. When that flag is present, the dashboard switches to a
+viewer mode that:
+
+- Fetches `/settings` (same endpoint as today)
+- Syntax-highlights the JSON in-browser (custom JS tokenizer)
+- Provides a **Refresh** button
+- Provides a **Download** button (saves the JSON as a file)
+- Renders with sticky action buttons and full-screen scroll
+
+All of this lives inline in `data/index.html` — 179 lines of new JavaScript and
+markup. Plus:
+
+- `data/styling.css`: 58 new lines of viewer-specific styles
+- `packfs.py`: 55 lines of pack-time changes (probably adds the new asset /
+  gzips CSS)
+- `platformio.ini`: 12 lines (pack-dependency updates)
+- `.gitignore`: 1 line
+
+## Fork state
+
+The fork's web UI has diverged significantly from upstream:
+
+| Fork divergence | Mentioned in |
+|---|---|
+| Offline-first web UI (no CDN) | `docs/upstream-differences.md` "Web & Connectivity" |
+| WebSocket data channel replaces HTTP polling | same |
+| Dashboard card redesign | same |
+| Dark mode | same |
+| Load balancing node overview | same |
+| Diagnostic telemetry viewer | same |
+| LCD widget modernization | same |
+
+File-level diffs:
+
+| File | Upstream | Fork |
+|---|---|---|
+| Dashboard HTML | `data/index.html` (same path) | `data/index.html` — 500 lines, heavily customized |
+| Stylesheet | `data/styling.css` (NEW in upstream) | `data/style.css` (existing, different name) |
+| Pack script | `packfs.py` at repo root | `SmartEVSE-3/packfs.py` (fork has its own) |
+
+The fork's existing "Raw Data" UX:
+
+```html
+<a class="btn btn-sm" href="/settings" data-ajax="false" title="Raw JSON settings">Raw Data</a>
+```
+
+Clicking this opens the raw JSON in a new tab — browser renders it as-is. No
+syntax highlighting, no download button, but functional.
+
+## Why deferring is the right call
+
+1. **High merge conflict risk.** 179 lines of new inline JS slotted into a
+   500-line file whose surrounding structure has been substantially rewritten
+   by the fork. Line-by-line merge would fight both sides' intent.
+
+2. **Stylesheet rename.** Upstream adds `styling.css`; fork uses `style.css`
+   with its own ruleset. Merging requires renaming or duplicating.
+
+3. **Pack script is custom.** `SmartEVSE-3/packfs.py` in the fork doesn't match
+   the path or structure upstream edits. Cannot apply patch mechanically.
+
+4. **Fork has its own Web UI plan.** `CLAUDE.md` lists **Plan 07 Web UI
+   Modernization** as P4 ("largest scope, least safety-critical, back of
+   backlog"). An incoming JSON viewer improvement is exactly the kind of thing
+   Plan 07 should consider — possibly redesigning the whole settings surface,
+   not patching the current dashboard.
+
+5. **No safety or functional regression from deferring.** Users can still view
+   settings via the existing Raw Data link. The download capability is a
+   convenience, not a required feature.
+
+6. **Context budget.** Each P3 adaptation of this size eats significant time
+   and reviewer attention. Better to focus reviewer attention on the P1/P2
+   safety fixes that have already landed.
+
+## Pre-integration checklist (if revived later)
+
+1. [ ] Decide whether to keep it as an in-page mode (`?raw=1`) or a standalone
+       `/raw.html` page. Upstream chose in-page; `/raw.html` would avoid
+       touching the main dashboard.
+2. [ ] Reconcile `styling.css` vs fork's `style.css`. Options:
+       - Add a new `raw.css` served only on the viewer page
+       - Fold upstream's 58 lines into fork's `style.css` under a scoped class
+3. [ ] Port `packfs.py` changes to the fork's layout.
+4. [ ] Decide whether the dashboard gets the viewer, or the diagnostic panel
+       (Plan 06) absorbs it.
+5. [ ] On-device test: render large `/settings` JSON without JS timeout on ESP32's
+       WebSocket path.
+6. [ ] On-device test: download produces a valid `.json` file in common browsers.
+7. [ ] Consider whether the same viewer should serve the diag telemetry feed.
+
+## Decision
+
+**Defer.** Track as input for Plan 07. No code changes needed now. The
+existing Raw Data link covers the baseline need.

--- a/docs/upstream-sync/sync-state.md
+++ b/docs/upstream-sync/sync-state.md
@@ -22,7 +22,7 @@ Prior sync window (2026-03-29, now closed): 2 integrated (PR #130), 1 rejected,
 | 5 | `543af26` | 2026-04-01 | stegen | EtherLCD support: Ethernet add-on board that replaces the LCD board (#349) | New feature — hardware | P3 | — | **1768 lines**, 11 files, hardware-specific. Evaluate whether fork users want this; substantial review. |
 | 6 | `afd72a8` | 2026-04-03 | stegen | OCPP: send Finishing state before Available (fixes #348) | **Integrated** | P2 | (P2 bundle) | Decision extracted to `ocpp_should_report_occupied()` in ocpp_logic.c; 6 unit tests |
 | 7 | `74e20c8` | 2026-04-07 | stegen | `main.cpp`: reset ChargeDelay countdown when solar power disappears (master) | **Integrated** | P2 | (P2 bundle) | Ported into pure C `evse_tick_1s()`; 3 unit tests in test_tick_1s.c |
-| 8 | `2c015fb` | 2026-04-08 | Juurlink | Improved Raw Settings view: formatted JSON + Download button (#353) | Web UI feature | P3 | — | 280/25 lines, 5 files. Useful; likely conflicts with fork web UI divergences. |
+| 8 | `2c015fb` | 2026-04-08 | Juurlink | Improved Raw Settings view: formatted JSON + Download button (#353) | **Evaluated — defer to Plan 07** | P3 | — | 280/25 lines lands in fork's 500-line diverged `index.html`; stylesheet rename collision (`styling.css` vs fork `style.css`); `packfs.py` path differs. No functional regression from keeping existing Raw Data link. See [analysis](analysis-2c015fb-raw-settings-ui.md). |
 | 9 | `3ab1cee` | 2026-04-08 | stegen | `main.cpp`: reset Node ChargeDelay countdown when solar power disappears | **Integrated** | P2 | (P2 bundle) | Applied in `processAllNodeStates()` master-side slave-node error tracking |
 | 10 | `a54b07f` | 2026-04-09 | stegen | `main.cpp`: prevent current fluctuations when CAPACITY is used (fixes #327) | **Integrated** | P2 | (P2 bundle) | Applied in pure C `evse_calc_balanced_current()`; 3 unit tests. `test_s9_maxsummains_limits` updated to use larger exceedance (Isum 350→600) so per-phase reduction crosses fork's SmartDeadBand — documents the gentler, correct per-phase semantics. |
 | 11 | `92d42eb` | 2026-04-10 | Juurlink | Refactor tooltips: centralize styles in `styling.css` + a11y (#301) | Web UI cosmetic | P4 | — | CSS-only. |
@@ -40,7 +40,7 @@ Prior sync window (2026-03-29, now closed): 2 integrated (PR #130), 1 rejected,
    - #10 `a54b07f` CAPACITY current fluctuation — review for overlap with Plan 13
 3. **Features (P3) — each as separate PR:**
    - #12 `3679fe3` OCPP LED scheme — adapt into `led_color.c`
-   - #8 `2c015fb` Raw Settings UI — evaluate against fork web UI
+   - #8 `2c015fb` Raw Settings UI — **evaluated and deferred** to Plan 07 (Web UI Modernization); see analysis
    - #5 `543af26` EtherLCD — biggest item, stand-alone evaluation
 4. **Cosmetic / docs (P4) — batch or skip:**
    - #4 `4e6c06d` update2.html


### PR DESCRIPTION
## Summary

Records the evaluation of upstream [\`2c015fb\`](https://github.com/dingo35/SmartEVSE-3.5/commit/2c015fb) ("Improved Raw Settings view with formatted JSON and Download button", #353).

**Verdict: defer to a future Plan 07 (Web UI Modernization) PR.**

## Why defer

| Reason | Detail |
|---|---|
| Merge-conflict risk | 179 lines of inline JS slotted into fork's 500-line customized \`index.html\` |
| Stylesheet rename | Upstream adds \`styling.css\`; fork uses \`style.css\` |
| Pack script divergence | \`SmartEVSE-3/packfs.py\` in fork doesn't match upstream patch paths |
| Plan 07 on backlog | Fork has its own P4 Web UI modernization plan that should consume this idea |
| No functional regression | Existing "Raw Data" link still opens \`/settings\` JSON in the browser |

## This PR

Doc-only. Adds \`docs/upstream-sync/analysis-2c015fb-raw-settings-ui.md\` with full compatibility audit + pre-integration checklist, and marks #8 as "Evaluated — defer to Plan 07" in \`sync-state.md\`.

## Triage progress (2026-04-13 window)

| # | Status |
|---|---|
| 1 \`e6110b1\` P1 cable-detect | Merged via #133 |
| 2 \`cdc8f67\` | Already fixed by fork |
| 3,6,7,9,10 P2 bundle | Merged via #134 |
| 12 \`3679fe3\` P3 LED scheme | Merged via #135 |
| 8 \`2c015fb\` | **Deferred** (this PR) |
| 4, 11, 13 P4 cosmetic/docs | Next |
| 5 \`543af26\` EtherLCD | Last (long-lived branch per user direction) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)