### PR TITLE
upstream: P4 batch — update2.html cosmetics + OCPP docs rewrite

### DIFF
--- a/SmartEVSE-3/data/update2.html
+++ b/SmartEVSE-3/data/update2.html
@@ -64,15 +64,15 @@ var setStatus = function(text) {
   <body onload="loadData()">
     <div id="container">
       <div id="info">
-          Current version: <span id="version"></span>
-          =======================================================
-          DOWNLOADING
+          Current version: <span id="version"></span><br>
+          =========================================================================================<br>
+          UPDATE FIRMWARE
           <br><br>
           <table style='text-align: left'>
             <tr>
               <th>Distribution:</th>
               <th>Status:</th>
-              <th>Github repo:</th>
+              <th>Github release notes:</th>
               <th>Latest version:</th>
               <th>Flash:</th>
             </tr>
@@ -106,9 +106,8 @@ var setStatus = function(text) {
             </tr>
           </table>
           <br>
-          =======================================================
-          <br>
-          FLASHING
+          =========================================================================================<br>
+          CUSTOM FLASHING
           <br><br>
           Flash one of:<ul>
               <li>firmware.bin or firmware.signed.bin (to update the firmware);</li>
@@ -116,10 +115,11 @@ var setStatus = function(text) {
               <li>rfid.txt (if you want to bulk upload allowed NFC tags for the RFID reader);</li>
           </ul>
           You should only flash files with those exact names.<br>No need to flash spiffs.bin for versions 3.6.0-RC1 and newer!<br>No need to rename firmware.debug.bin anymore for versions 3.6.0-RC2 and newer!<br>Signed firmware is verified to be original and can be handled by versions 3.6.2 and newer.
+          <br><br><br>NOTE: "Choose file:"  uploads only work with http connections, and will fail with https connections!<br>
       </div>
       <div id="wrapper">
         <input type="file" id="el1" style="display: none"/>
-        <button id="el2">choose file...</button>
+        <button id="el2">Choose file...</button>
         <div id="el3"></div>
       </div>
     </div>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -503,15 +503,23 @@ Up to eight SmartEVSE modules can share one mains supply.
 - Set one SmartEVSE PWR SHARE setting to MASTER, and the others to NODE 1-7. Make sure there is only one Master, and the Node numbers are unique.
 - See [Master setup](#master-setup-power-share) and [Node setup](#node-setup-power-share) above for step-by-step instructions.
 
-# OCPP (you want your company to pay for your electricity charges, or you want to exploit your SmartEVSE as a public charger)
-To charge a company or a user for your electricity cost, you need a Backend Provider (BP). The BP will monitor your charger usage and will bill the appropriate user and/or company, and will pay you your part.
-Your SmartEVSE can be connected to any BP by the OCPP protocol.
-See the OCPP section in the SmartEVSE dashboard for setting up identifiers and configuring the OCPP interface.
-Connect to the OCPP server using the credentials set up in the SmartEVSE dashboard. To use
-the RFID reader with OCPP, set the mode Rmt/OCPP in the RFID menu. Note that the other
-RFID modes overrule the OCPP access control. OCPP SmartCharging requires the SmartEVSE
-internal load balancing needs to be turned off.
-For user experiences with back-end providers, see [OCPP Backends](ocpp.md)
+# OCPP (Open Charge Point Protocol)
+
+Connect your charge point to a backend server. This allows you to use the SmartEVSE as a public charging station, or to bill a company or user for electricity costs.
+
+## Setup
+
+You will need a Backend Provider (BP) that supports the **OCPP 1.6j** protocol. The BP monitors your charger usage, bills the appropriate user and/or company, and pays you your share.
+
+1. Configure the OCPP connection in the **OCPP section** of the SmartEVSE dashboard (identifiers, server URL, credentials).
+2. Configure an [EV METER](#ev-meter) to measure the energy supplied to the car.
+3. To use the **RFID reader** with OCPP, set the [RFID](#rfid) mode to **Rmt/OCPP**. Note that other RFID modes override OCPP access control.
+
+## Requirements and limitations
+
+- If the backend uses **OCPP SmartCharging** the SmartEVSE internal power sharing [PWR SHARE](#pwr-share) has to be turned off.
+
+For user experiences with backend providers, see [OCPP Backends](ocpp.md).
 
 # REST API
 

--- a/docs/upstream-sync/sync-state.md
+++ b/docs/upstream-sync/sync-state.md
@@ -4,7 +4,7 @@ Tracks integration status of upstream commits from `dingo35/SmartEVSE-3.5`.
 
 **Last synced to:** `ecd088b` (2026-03-29, 2026-03-29 triage closed)
 **Current upstream HEAD:** `790f2a9` (2026-04-10)
-**Open pending commits (2026-04-13 window):** 13 — triage below
+**Open pending commits (2026-04-13 window):** 1 (EtherLCD deferred to long-lived branch per user direction) + 3 deferred-to-Plan-07 (UI). 9 integrated, 1 rejected-pre-fix, 1 already-fixed.
 
 Prior sync window (2026-03-29, now closed): 2 integrated (PR #130), 1 rejected,
 1 evaluated/deferred (190777f), 1 skipped.
@@ -18,16 +18,16 @@ Prior sync window (2026-03-29, now closed): 2 integrated (PR #130), 1 rejected,
 | 1 | `e6110b1` | 2026-03-31 | stegen | Fix cable disconnect not detected when switching to PAUSE (fixes #347) | **Integrated** | **P1** | #133 | Applied in `evse_bridge.cpp` STATE_A/B1 and STATE_C1 paths (2-line fix) |
 | 2 | `cdc8f67` | 2026-03-31 | dingo35 | Prevent `[Mains\|EV]Meter.[Im\|Ex]port_active_energy` exported when zero | **Already fixed** | — | — | Fork already has broader `> 0` guards at `esp32.cpp:1257-1300` + Circuit meter. No action. |
 | 3 | `b104576` | 2026-03-31 | stegen | `modbus.cpp`: do not advance request loop on broadcast timeouts | **Integrated** | P2 | (P2 bundle) | Verbatim; 1-line guard on `BROADCAST_ADR` |
-| 4 | `4e6c06d` | 2026-04-01 | dingo35 | `update2.html`: warning message + layout | Web UI cosmetic | P4 | — | `data/` HTML → `packed_fs.c` regen |
+| 4 | `4e6c06d` | 2026-04-01 | dingo35 | `update2.html`: warning message + layout | **Integrated** | P4 | (P4 batch) | Applied verbatim to fork's update2.html (label clarity, HTTPS-upload warning, button caps) |
 | 5 | `543af26` | 2026-04-01 | stegen | EtherLCD support: Ethernet add-on board that replaces the LCD board (#349) | New feature — hardware | P3 | — | **1768 lines**, 11 files, hardware-specific. Evaluate whether fork users want this; substantial review. |
 | 6 | `afd72a8` | 2026-04-03 | stegen | OCPP: send Finishing state before Available (fixes #348) | **Integrated** | P2 | (P2 bundle) | Decision extracted to `ocpp_should_report_occupied()` in ocpp_logic.c; 6 unit tests |
 | 7 | `74e20c8` | 2026-04-07 | stegen | `main.cpp`: reset ChargeDelay countdown when solar power disappears (master) | **Integrated** | P2 | (P2 bundle) | Ported into pure C `evse_tick_1s()`; 3 unit tests in test_tick_1s.c |
 | 8 | `2c015fb` | 2026-04-08 | Juurlink | Improved Raw Settings view: formatted JSON + Download button (#353) | **Evaluated — defer to Plan 07** | P3 | — | 280/25 lines lands in fork's 500-line diverged `index.html`; stylesheet rename collision (`styling.css` vs fork `style.css`); `packfs.py` path differs. No functional regression from keeping existing Raw Data link. See [analysis](analysis-2c015fb-raw-settings-ui.md). |
 | 9 | `3ab1cee` | 2026-04-08 | stegen | `main.cpp`: reset Node ChargeDelay countdown when solar power disappears | **Integrated** | P2 | (P2 bundle) | Applied in `processAllNodeStates()` master-side slave-node error tracking |
 | 10 | `a54b07f` | 2026-04-09 | stegen | `main.cpp`: prevent current fluctuations when CAPACITY is used (fixes #327) | **Integrated** | P2 | (P2 bundle) | Applied in pure C `evse_calc_balanced_current()`; 3 unit tests. `test_s9_maxsummains_limits` updated to use larger exceedance (Isum 350→600) so per-phase reduction crosses fork's SmartDeadBand — documents the gentler, correct per-phase semantics. |
-| 11 | `92d42eb` | 2026-04-10 | Juurlink | Refactor tooltips: centralize styles in `styling.css` + a11y (#301) | Web UI cosmetic | P4 | — | CSS-only. |
+| 11 | `92d42eb` | 2026-04-10 | Juurlink | Refactor tooltips: centralize styles in `styling.css` + a11y (#301) | **Evaluated — defer to Plan 07** | P4 | — | Same `styling.css` vs fork's `style.css` naming collision as #8 (2c015fb). Tooltip refactor + a11y improvements are nice-to-have; fold into Plan 07 Web UI Modernization when executed. No functional regression. |
 | 12 | `3679fe3` | 2026-04-10 | stegen | OCPP: public charging station LED colour scheme when OCPP is enabled (#351) | **Integrated** | P3 | (this PR) | Public scheme extracted to `led_public_compute()` in `led_color.c`; 14 unit tests. `MENU_LEDMODE=51` (fork avoids renumber cascade). |
-| 13 | `790f2a9` | 2026-04-10 | stegen | `docs`: update OCPP documentation | Docs only | P4 | — | Skip or cherry-pick docs bits. |
+| 13 | `790f2a9` | 2026-04-10 | stegen | `docs`: update OCPP documentation | **Integrated (adapted)** | P4 | (P4 batch) | Applied the restructured OCPP section to `docs/configuration.md`. Omitted the "Remote firmware updates over OCPP" claim — that's the 190777f feature which is deferred in the fork. |
 
 ### Suggested batching
 
@@ -42,10 +42,10 @@ Prior sync window (2026-03-29, now closed): 2 integrated (PR #130), 1 rejected,
    - #12 `3679fe3` OCPP LED scheme — adapt into `led_color.c`
    - #8 `2c015fb` Raw Settings UI — **evaluated and deferred** to Plan 07 (Web UI Modernization); see analysis
    - #5 `543af26` EtherLCD — biggest item, stand-alone evaluation
-4. **Cosmetic / docs (P4) — batch or skip:**
-   - #4 `4e6c06d` update2.html
-   - #11 `92d42eb` tooltip CSS
-   - #13 `790f2a9` OCPP docs update
+4. **Cosmetic / docs (P4) — processed:**
+   - #4 `4e6c06d` update2.html — **integrated**
+   - #11 `92d42eb` tooltip CSS — **deferred to Plan 07** (styling.css name collision)
+   - #13 `790f2a9` OCPP docs update — **integrated (adapted)**
 5. **No action (already fixed):**
    - #2 `cdc8f67` energy zero-value guard — noted, no action
 


### PR DESCRIPTION
## Summary

P4 cosmetic/docs batch from the 2026-04-13 sync window. 2 integrated, 1 deferred.

| Upstream | Title | Action |
|---|---|---|
| [\`4e6c06d\`](https://github.com/dingo35/SmartEVSE-3.5/commit/4e6c06d) | \`update2.html\`: warning message + layout | **Integrated** (verbatim) |
| [\`790f2a9\`](https://github.com/dingo35/SmartEVSE-3.5/commit/790f2a9) | \`docs\`: update OCPP documentation | **Integrated (adapted)** — omitted "remote FW update" line because 190777f is deferred in fork |
| [\`92d42eb\`](https://github.com/dingo35/SmartEVSE-3.5/commit/92d42eb) | Refactor tooltips: centralize styles in \`styling.css\` + a11y | **Deferred to Plan 07** — same \`styling.css\` vs \`style.css\` naming collision as #8 (2c015fb) |

## Changes

### \`update2.html\`
- Section labels: "DOWNLOADING" → "UPDATE FIRMWARE"; "FLASHING" → "CUSTOM FLASHING"
- Table header: "Github repo" → "Github release notes"
- Button: "choose file..." → "Choose file..."
- New **warning about HTTPS file-upload failing** (known ESP32 quirk)
- Consistent separator line width

### \`docs/configuration.md\` (OCPP section)
- Restructured with **Setup** + **Requirements and limitations** sub-headings
- Numbered step-by-step setup
- Cross-references to EV METER / RFID / PWR SHARE menu sections
- **Omitted upstream's "Remote firmware updates over OCPP" claim** — that comes from 190777f which is deferred in the fork (pending on-device CSMS verification)

## Verification

Doc + HTML only; no pure C changed. ESP32 firmware build passes (pre:packfs.py re-packs the updated HTML into \`packed_fs.c\`).

## Triage progress for 2026-04-13 window

| # | Commit | Status |
|---|---|---|
| 1 | \`e6110b1\` P1 cable-detect | Merged #133 |
| 2 | \`cdc8f67\` | Already fixed by fork |
| 3,6,7,9,10 | P2 bundle | Merged #134 |
| 12 | \`3679fe3\` P3 LED scheme | Merged #135 |
| 8 | \`2c015fb\` | Deferred to Plan 07 (#136) |
| 4, 13 | P4 cosmetic/docs | **This PR** |
| 11 | \`92d42eb\` | **Deferred to Plan 07** (this PR) |
| 5 | \`543af26\` EtherLCD | Last — long-lived branch (per user direction, weeks of on-device testing) |

After this merges, the 2026-04-13 window is closed except for EtherLCD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)