### PR TITLE
security(C-1): reject unsigned firmware uploads at /update

### DIFF
--- a/SmartEVSE-3/data/update2.html
+++ b/SmartEVSE-3/data/update2.html
@@ -110,11 +110,11 @@ var setStatus = function(text) {
           CUSTOM FLASHING
           <br><br>
           Flash one of:<ul>
-              <li>firmware.bin or firmware.signed.bin (to update the firmware);</li>
-              <li>firmware.debug.bin or firmware.debug.signed.bin (if you want to telnet to your SmartEVSE to see debug messages);</li>
+              <li>firmware.signed.bin (to update the firmware);</li>
+              <li>firmware.debug.signed.bin (if you want to telnet to your SmartEVSE to see debug messages);</li>
               <li>rfid.txt (if you want to bulk upload allowed NFC tags for the RFID reader);</li>
           </ul>
-          You should only flash files with those exact names.<br>No need to flash spiffs.bin for versions 3.6.0-RC1 and newer!<br>No need to rename firmware.debug.bin anymore for versions 3.6.0-RC2 and newer!<br>Signed firmware is verified to be original and can be handled by versions 3.6.2 and newer.
+          You should only flash files with those exact names.<br>No need to flash spiffs.bin for versions 3.6.0-RC1 and newer!<br><b>Unsigned firmware.bin uploads are no longer accepted</b> — only signature-verified .signed.bin files are flashed (security fix). Build signed firmware locally via the release workflow or use the prebuilt assets from the releases page.
           <br><br><br>NOTE: "Choose file:"  uploads only work with http connections, and will fail with https connections!<br>
       </div>
       <div id="wrapper">

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -1591,33 +1591,19 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
               mg_http_reply(c, 400, "", "size required");
               res = -5;
             } else {
+                // NOTE: the unsigned firmware.bin / firmware.debug.bin upload path
+                // was removed as SECURITY FIX C-1 — it allowed any LAN client to
+                // flash arbitrary firmware over plain HTTP with no authentication
+                // and no signature check (unauthenticated RCE). Only the signed
+                // upload path below is supported now; fork/upstream-signed images
+                // are both accepted via the multi-key validator from PR #125.
                 if (!memcmp(file,"firmware.bin", sizeof("firmware.bin")) || !memcmp(file,"firmware.debug.bin", sizeof("firmware.debug.bin"))) {
-                    if(!offset) {
-                        _LOG_A("Update Start: %s\n", file);
-                        if(!Update.begin((ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000), U_FLASH) {
-                            _LOG_A("ERROR: Update has error:%s.\n", Update.errorString());
-                            Update.printError(Serial);
-                        }
-                    }
-                    if(!Update.hasError()) {
-                        if(Update.write((uint8_t*) hm->body.buf, hm->body.len) != hm->body.len) {
-                            _LOG_A("ERROR: Update has error:%s.\n", Update.errorString());
-                            Update.printError(Serial);
-                        } else {
-                            _LOG_A("bytes written %lu\r", offset + hm->body.len);
-                        }
-                    }
-                    if (offset + hm->body.len >= size) {                                           //EOF
-                        if(Update.end(true)) {
-                            _LOG_A("\nUpdate Success\n");
-                            delay(1000);
-                            ESP.restart();
-                        } else {
-                            _LOG_A("ERROR: Update has error:%s.\n", Update.errorString());
-                            Update.printError(Serial);
-                        }
-                    }
-                } else //end of firmware.bin
+                    _LOG_A("Unsigned firmware upload rejected: %s (security C-1)\n", file);
+                    mg_http_reply(c, 403, "",
+                                  "Unsigned firmware uploads are disabled. "
+                                  "Upload firmware.signed.bin or firmware.debug.signed.bin instead.");
+                    res = -6;
+                } else
                 if (!memcmp(file,"firmware.signed.bin", sizeof("firmware.signed.bin")) || !memcmp(file,"firmware.debug.signed.bin", sizeof("firmware.debug.signed.bin"))) {
     #define dump(X)   for (int i= 0; i< SIGNATURE_LENGTH; i++) _LOG_A_NO_FUNC("%02x", X[i]); _LOG_A_NO_FUNC(".\n");
                     if(!offset) {

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -20,7 +20,7 @@ Once your Wi-Fi parameters are configured, your SmartEVSE will be accessible on 
 ### Firmware Updates (OTA)
 
 * Navigate to `http://<your-smartevse>/update` or press the "UPDATE" button on the webserver.
-* Upload the `firmware.bin` file from this archive, or use `firmware.debug.bin` renamed to `firmware.bin` for a debug version (accessible via Telnet). Ensure the file name is correct; otherwise, flashing will fail.
+* Upload `firmware.signed.bin` (or `firmware.debug.signed.bin` for the Telnet debug build). Only RSA-signed images are accepted — the fork rejects unsigned uploads as a security measure.
 * In case of failure (FAIL), check your Wi-Fi connection and retry.
 * After a successful update (OK), wait 10-30 seconds for the firmware, including the webserver, to go online.
 

--- a/docs/upstream-differences.md
+++ b/docs/upstream-differences.md
@@ -177,6 +177,14 @@ Addresses upstream issues
 | Diagnostic telemetry viewer | No way to view diagnostics in browser | [Features: Web](features.md#web--connectivity) |
 | LCD widget modernization | Old layout, not responsive | [Features: Web](features.md#web--connectivity) |
 
+### Security Hardening (Fork-only)
+
+Findings from the security review (see internal report; most issues are inherited from upstream).
+
+| Fix | Why | Details |
+|-----|-----|---------|
+| Unsigned firmware upload rejected at `POST /update` | Upstream accepts `firmware.bin` / `firmware.debug.bin` uploads over unauthenticated HTTP with no signature check → any LAN client can flash arbitrary firmware (unauthenticated RCE). Fork accepts only `*.signed.bin` — verified via the multi-key RSA validator from PR #125 | Security fix C-1 |
+
 ---
 
 ## Contributing Upstream


### PR DESCRIPTION
**Security fix — Critical. Unauthenticated remote code execution on any LAN.**

## Summary

The \`/update\` HTTP handler accepted \`firmware.bin\` and \`firmware.debug.bin\` uploads over unauthenticated HTTP and piped the body straight to \`Update.write()\` + \`Update.end(true)\` without any signature verification. Any device on the same LAN could flash arbitrary firmware and completely take over the charger.

This PR removes that code path. Only \`*.signed.bin\` uploads are accepted now, and those go through \`firmware_manager.cpp\`'s multi-key RSA verifier (PR #125).

## The bug

\`SmartEVSE-3/src/network_common.cpp\` \`/update\` handler, pre-fix:

\`\`\`cpp
if (!memcmp(file, "firmware.bin", ...) || !memcmp(file, "firmware.debug.bin", ...)) {
    if (!offset) Update.begin(...);
    Update.write((uint8_t*) hm->body.buf, hm->body.len);   // ← arbitrary bytes
    if (offset + hm->body.len >= size) {
        Update.end(true);                                    // ← commit without signature
        ESP.restart();
    }
}
\`\`\`

No authentication check, no signature check. Every fork and upstream \`dingo35\` device currently shipping accepts arbitrary firmware from anyone on the same LAN.

Trivial reproducer (do not run against other people's chargers):

\`\`\`bash
curl -X POST 'http://<charger-ip>/update?file=firmware.bin&offset=0&size=<len>' \
     --data-binary @malicious-firmware.bin
\`\`\`

## Fix

Remove the \`firmware.bin\` / \`firmware.debug.bin\` acceptance branch. Replace with HTTP 403 and an explanatory message. The \`.signed.bin\` branch below is unchanged — signed uploads still work, and the multi-key validator accepts both upstream-signed and fork-signed images.

## User-visible impact

- Web UI flashing now requires \`firmware.signed.bin\` (or \`firmware.debug.signed.bin\`). Both are produced by the existing release / nightly workflows.
- Local dev builds of unsigned firmware continue to work via \`pio run -t upload\` over serial — that path requires physical access to the device.
- \`update2.html\` + \`docs/operation.md\` updated to document the new requirement.
- \`docs/upstream-differences.md\` now has a new **Security Hardening** section noting this divergence.

## Context

This issue is inherited from upstream \`dingo35/SmartEVSE-3.5\` — it is not fork-introduced. Considering a joint disclosure / upstream-fix PR separately. Fork is not waiting for upstream before shipping the fix.

## Test plan

- [x] \`make clean test\` — 51 suites, all pass
- [x] \`pio run -e release\` — SUCCESS
- [ ] **On-device:** flash the new firmware, try uploading \`firmware.bin\` via web UI → should be rejected with a clear error message
- [ ] **On-device:** upload \`firmware.signed.bin\` via web UI → should flash successfully (signed path unchanged)
- [ ] **On-device:** verify \`POST /autoupdate\` (the release-artifact autoupdate path) still works — it always used \`.signed.bin\`, unaffected

## Related

- Security finding **C-1** from the internal security review.
- Builds on signing infrastructure from PR #125 (multi-key RSA validation).
- Affects the same \`/update\` code path touched by the earlier workflow fixes in PR #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)