### PR TITLE
security(C-5, H-5): redact MQTT secret from log + NUL-terminate strncpy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,17 @@ in embedded firmware is high.
 - **Never bypass error checks or safety validations.** Do not remove or weaken
   bounds checking, overcurrent protection, or state machine guard conditions.
 - **Never use `sprintf`.** Always use `snprintf` with explicit buffer sizes.
+- **Always NUL-terminate after `strncpy`.** `strncpy(buf, src, sizeof(buf))` does
+  NOT write a terminator when the source fills the buffer. Every `strncpy` MUST
+  be followed by `buf[sizeof(buf) - 1] = '\0';`. Prefer `snprintf(buf, sizeof(buf), "%s", src)`
+  when possible — it always terminates. Rule introduced after security review
+  finding H-5 (MQTT/NVS input into `RequiredEVCCID` could leave the buffer
+  unterminated, causing subsequent `%s` reads past the end).
+- **Never log secrets.** Do not pass credential material (MQTT passwords, OCPP
+  auth keys, private-key-derived tokens, WiFi passwords, pairing PINs, RFID
+  UIDs) to `_LOG_A` / `_LOG_I` / `Serial.print` / `printf`. A short fingerprint
+  (first 4 chars + ellipsis) is acceptable for debugging. Rule introduced after
+  security review finding C-5 (`MQTTprivatePassword` was printed on every boot).
 - **Never allocate heap memory in ISRs, timer callbacks, or critical sections.**
   No `malloc`, `new`, Arduino `String`, or any blocking call inside
   `portENTER_CRITICAL` / `portEXIT_CRITICAL` blocks.

--- a/SmartEVSE-3/src/esp32.cpp
+++ b/SmartEVSE-3/src/esp32.cpp
@@ -751,7 +751,10 @@ void mqtt_receive_callback(const String topic, const String payload) {
 
         case MQTT_CMD_REQUIRED_EVCCID:
 #if MODEM
+            // SECURITY H-5: strncpy does NOT NUL-terminate when the source fills the buffer.
+            // Without the explicit NUL, the subsequent %s read walks past the buffer end.
             strncpy(RequiredEVCCID, cmd.evccid, sizeof(RequiredEVCCID));
+            RequiredEVCCID[sizeof(RequiredEVCCID) - 1] = '\0';
             Serial1.printf("@RequiredEVCCID:%s\n", RequiredEVCCID);
             request_write_settings();
 #endif
@@ -1641,7 +1644,10 @@ void read_settings() {
 
         EnableC2 = (EnableC2_t) preferences.getUShort("EnableC2", ENABLE_C2);
 #if MODEM
+        // SECURITY H-5: NUL-terminate after strncpy — preferences.getString() can
+        // return a string exactly sizeof(RequiredEVCCID) bytes long.
         strncpy(RequiredEVCCID, preferences.getString("RequiredEVCCID", "").c_str(), sizeof(RequiredEVCCID));
+        RequiredEVCCID[sizeof(RequiredEVCCID) - 1] = '\0';
 #endif
         maxTemp = preferences.getUShort("maxTemp", MAX_TEMPERATURE);
         PrioStrategy = preferences.getUChar("PrioStrategy", PRIO_MODBUS_ADDR);
@@ -1707,6 +1713,7 @@ void read_settings() {
         settingsCache.EnableC2 = EnableC2;
 #if MODEM
         strncpy(settingsCache.RequiredEVCCID, RequiredEVCCID, sizeof(settingsCache.RequiredEVCCID));
+        settingsCache.RequiredEVCCID[sizeof(settingsCache.RequiredEVCCID) - 1] = '\0';  // SECURITY H-5
 #endif
         settingsCache.maxTemp = maxTemp;
         settingsCache.PrioStrategy = PrioStrategy;
@@ -1792,6 +1799,7 @@ void write_settings(void) {
     if (!settingsCache.valid || strcmp(RequiredEVCCID, settingsCache.RequiredEVCCID) != 0) {
         preferences.putString("RequiredEVCCID", String(RequiredEVCCID));
         strncpy(settingsCache.RequiredEVCCID, RequiredEVCCID, sizeof(settingsCache.RequiredEVCCID));
+        settingsCache.RequiredEVCCID[sizeof(settingsCache.RequiredEVCCID) - 1] = '\0';  // SECURITY H-5
     }
 #endif
     PREFS_PUT_USHORT_IF_CHANGED("maxTemp", maxTemp, maxTemp);

--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -2077,7 +2077,14 @@ void WiFiSetup(void) {
         _LOG_A("No serialnr programmed, using MAC: %u\n", serialnr);
     }
     
-    _LOG_A("hwversion=%04x serialnr=%u mqtt_pwd=%s\n", hwversion, serialnr, MQTTprivatePassword.c_str());
+    // SECURITY C-5: do NOT log the full MQTTprivatePassword (hash of EC
+    // private key used to authenticate to mqtt.smartevse.nl). Anyone who
+    // captures the boot log — serial, telnet, cloud-forwarded — could
+    // impersonate the device against the app server. Log a short prefix
+    // only as an aid for debugging, never the full secret.
+    _LOG_A("hwversion=%04x serialnr=%u mqtt_pwd=%.4s...[redacted]\n",
+           hwversion, serialnr,
+           MQTTprivatePassword.length() >= 4 ? MQTTprivatePassword.c_str() : "----");
 
 #ifndef SENSORBOX_VERSION
     APhostname = "SmartEVSE-" + String(serialnr);


### PR DESCRIPTION
**Security fixes.** Two unrelated small findings bundled because they share the follow-up CLAUDE.md hardening rules.

## C-5 — MQTT private password logged on every boot

\`network_common.cpp:2080\` previously emitted the full hash of the device's EC private key:

\`\`\`
[BOOT] hwversion=0030 serialnr=12345 mqtt_pwd=a7b2c9…[full 64-char hex]
\`\`\`

That hash authenticates the charger to \`mqtt.smartevse.nl\`. Anyone with log access could impersonate the device at the app server. Now logs a 4-char prefix + \`[redacted]\` — diagnostic value preserved, secret not exposed.

## H-5 — \`strncpy\` into \`RequiredEVCCID\` leaves the buffer unterminated

Four call sites in \`esp32.cpp\` filled \`RequiredEVCCID\` without an explicit terminator. When the 32-byte field is completely filled, the subsequent \`Serial1.printf("%s", RequiredEVCCID)\` walks past the buffer end — disclosure of whatever is adjacent in memory, or crash.

- Line 754 — MQTT command handler (attacker-controllable via broker)
- Line 1644 — NVS preferences load
- Lines 1709, 1794 — cache propagation

Fix: every \`strncpy\` now followed by \`RequiredEVCCID[sizeof(...) - 1] = '\\0';\`.

## CLAUDE.md — two new Critical Rules

1. **Always NUL-terminate after strncpy.** With full rationale and \`snprintf\` preference.
2. **Never log secrets.** Enumerated list of credential classes; 4-char fingerprint allowed for debugging.

These rules are enforced by code review going forward. (A grep-based CI check could be added, but low ROI for now — the patterns are rare and the review reminder is sufficient.)

## Verification

- Native tests: 51 suites, all pass
- ESP32 release build: SUCCESS

## Test plan

- [x] Build green
- [x] Log redaction produces expected \`a7b2...[redacted]\` format
- [ ] **On-device:** boot with debug firmware → verify boot log shows \`mqtt_pwd=XXXX...[redacted]\` with only 4 hex chars
- [ ] **On-device:** send a 32-byte EVCCID via MQTT \`/Set/EVCCID\` → verify no garbage appended on \`@RequiredEVCCID:\` echo

## Context

Both findings are inherited from upstream \`dingo35/SmartEVSE-3.5\`. Hard to exploit in practice (need log capture for C-5, need 32-byte exact-fit EVCCID for H-5), trivial to fix — closing them pre-emptively.

Related: security review findings **C-5** and **H-5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)