### PR TITLE
security(H-4): OCPP URL validator — reject SSRF targets + embedded creds

### DIFF
--- a/SmartEVSE-3/src/http_handlers.cpp
+++ b/SmartEVSE-3/src/http_handlers.cpp
@@ -742,6 +742,9 @@ bool handle_URI(struct mg_connection *c, struct mg_http_message *hm,  webServerR
                     if (vr != OCPP_VALIDATE_OK) {
                         doc["ocpp_backend_url"] = vr == OCPP_VALIDATE_EMPTY ? "URL is empty"
                                                 : vr == OCPP_VALIDATE_BAD_SCHEME ? "URL must start with ws:// or wss://"
+                                                : vr == OCPP_VALIDATE_EMBEDDED_CREDS ? "URL must not contain embedded user:pass@ credentials"
+                                                : vr == OCPP_VALIDATE_SSRF_LOOPBACK ? "URL must not point to the charger itself (loopback / 127.x / ::1)"
+                                                : vr == OCPP_VALIDATE_SSRF_LINK_LOCAL ? "URL must not point to link-local (169.254.x / fe80::)"
                                                 : "Invalid URL";
                     } else if (OcppWsClient) {
                         OcppWsClient->setBackendUrl(url);

--- a/SmartEVSE-3/src/ocpp_logic.c
+++ b/SmartEVSE-3/src/ocpp_logic.c
@@ -140,6 +140,58 @@ ocpp_lb_status_t ocpp_check_lb_exclusivity(uint8_t load_bl, bool ocpp_mode,
 
 /* ---- Settings validation ---- */
 
+/* Case-insensitive prefix compare, byte-level — avoids depending on strncasecmp
+ * availability in the pure-C build. */
+static bool ocpp_ci_has_prefix(const char *s, size_t s_len, const char *prefix) {
+    size_t p_len = strlen(prefix);
+    if (s_len < p_len) return false;
+    for (size_t i = 0; i < p_len; i++) {
+        char a = s[i], b = prefix[i];
+        if (a >= 'A' && a <= 'Z') a = (char)(a + ('a' - 'A'));
+        if (b >= 'A' && b <= 'Z') b = (char)(b + ('a' - 'A'));
+        if (a != b) return false;
+    }
+    return true;
+}
+
+/* SECURITY H-4: detect an IP literal or hostname that points to the charger
+ * itself or somewhere on the same node (SSRF). Also catches 0.0.0.0 which some
+ * stacks alias to loopback. The check is prefix-based on the raw authority,
+ * matching common forms written into an OCPP URL. */
+static bool ocpp_authority_is_loopback(const char *host, size_t host_len) {
+    if (ocpp_ci_has_prefix(host, host_len, "localhost")) {
+        /* Accept "localhost", "localhost:port", "localhost/path" — reject all */
+        if (host_len == 9) return true;
+        char c = host[9];
+        if (c == ':' || c == '/' || c == '\0') return true;
+    }
+    /* 127.0.0.0/8 — any address starting with 127. is loopback */
+    if (host_len >= 4 && host[0] == '1' && host[1] == '2' && host[2] == '7' && host[3] == '.') {
+        return true;
+    }
+    /* 0.0.0.0 — some stacks bind-any, resolves to loopback on connect */
+    if (host_len >= 7 && strncmp(host, "0.0.0.0", 7) == 0) {
+        char c = (host_len > 7) ? host[7] : '\0';
+        if (c == '\0' || c == ':' || c == '/') return true;
+    }
+    /* IPv6 loopback — raw "::1" or bracketed "[::1]" */
+    if (host_len >= 3 && strncmp(host, "::1", 3) == 0) {
+        char c = (host_len > 3) ? host[3] : '\0';
+        if (c == '\0' || c == ':' || c == '/') return true;
+    }
+    if (host_len >= 5 && strncmp(host, "[::1]", 5) == 0) return true;
+    return false;
+}
+
+/* SECURITY H-4: link-local addresses — the charger must never speak OCPP into
+ * the 169.254.0.0/16 AutoIP range or the IPv6 fe80::/10 link-local range. */
+static bool ocpp_authority_is_link_local(const char *host, size_t host_len) {
+    if (host_len >= 8 && strncmp(host, "169.254.", 8) == 0) return true;
+    if (ocpp_ci_has_prefix(host, host_len, "fe80:"))  return true;
+    if (ocpp_ci_has_prefix(host, host_len, "[fe80:")) return true;
+    return false;
+}
+
 ocpp_validate_result_t ocpp_validate_backend_url(const char *url) {
     if (!url || url[0] == '\0') {
         return OCPP_VALIDATE_EMPTY;
@@ -159,6 +211,32 @@ ocpp_validate_result_t ocpp_validate_backend_url(const char *url) {
         return OCPP_VALIDATE_BAD_SCHEME;
     }
 
+    /* SECURITY H-4: parse the authority (between scheme and first /?# or end)
+     * and run the anti-SSRF + anti-userinfo checks on just that portion.
+     * Characters permitted elsewhere in the URL (path/query) are not affected. */
+    const char *auth_start = url + scheme_len;
+    size_t auth_len = 0;
+    bool has_userinfo = false;
+    while (auth_start[auth_len] != '\0' &&
+           auth_start[auth_len] != '/'  &&
+           auth_start[auth_len] != '?'  &&
+           auth_start[auth_len] != '#') {
+        if (auth_start[auth_len] == '@') has_userinfo = true;
+        auth_len++;
+    }
+    if (has_userinfo) {
+        return OCPP_VALIDATE_EMBEDDED_CREDS;
+    }
+    if (auth_len == 0) {
+        return OCPP_VALIDATE_BAD_SCHEME;  /* scheme with no host */
+    }
+    if (ocpp_authority_is_loopback(auth_start, auth_len)) {
+        return OCPP_VALIDATE_SSRF_LOOPBACK;
+    }
+    if (ocpp_authority_is_link_local(auth_start, auth_len)) {
+        return OCPP_VALIDATE_SSRF_LINK_LOCAL;
+    }
+
     /* Validate characters after scheme: allow only URL-safe characters.
      * Reject control chars, spaces, CRLF injection, and other problematic chars. */
     for (size_t i = scheme_len; url[i] != '\0'; i++) {
@@ -170,7 +248,7 @@ ocpp_validate_result_t ocpp_validate_backend_url(const char *url) {
         /* Allowed URL special characters */
         if (c == '.' || c == ':' || c == '/' || c == '-' || c == '_' ||
             c == '?' || c == '=' || c == '&' || c == '@' || c == '%' ||
-            c == '+' || c == '#') {
+            c == '+' || c == '#' || c == '[' || c == ']') {
             continue;
         }
         return OCPP_VALIDATE_BAD_CHARS;

--- a/SmartEVSE-3/src/ocpp_logic.h
+++ b/SmartEVSE-3/src/ocpp_logic.h
@@ -101,11 +101,15 @@ ocpp_lb_status_t ocpp_check_lb_exclusivity(uint8_t load_bl, bool ocpp_mode,
 /* ---- Settings validation ---- */
 
 typedef enum {
-    OCPP_VALIDATE_OK          = 0,
-    OCPP_VALIDATE_EMPTY       = 1,
-    OCPP_VALIDATE_BAD_SCHEME  = 2,
-    OCPP_VALIDATE_TOO_LONG    = 3,
-    OCPP_VALIDATE_BAD_CHARS   = 4
+    OCPP_VALIDATE_OK               = 0,
+    OCPP_VALIDATE_EMPTY            = 1,
+    OCPP_VALIDATE_BAD_SCHEME       = 2,
+    OCPP_VALIDATE_TOO_LONG         = 3,
+    OCPP_VALIDATE_BAD_CHARS        = 4,
+    /* Added by security review H-4 — SSRF hardening: */
+    OCPP_VALIDATE_SSRF_LOOPBACK    = 5,  /* 127.x.x.x, localhost, 0.0.0.0, ::1 */
+    OCPP_VALIDATE_SSRF_LINK_LOCAL  = 6,  /* 169.254.x.x, fe80::/10 */
+    OCPP_VALIDATE_EMBEDDED_CREDS   = 7   /* userinfo (user:pass@host) in authority */
 } ocpp_validate_result_t;
 
 /*

--- a/SmartEVSE-3/test/native/tests/test_ocpp_settings.c
+++ b/SmartEVSE-3/test/native/tests/test_ocpp_settings.c
@@ -158,13 +158,16 @@ void test_url_space_rejected(void) {
  * @feature OCPP Settings Validation
  * @req REQ-OCPP-097
  * @scenario URL with valid special characters accepted
- * @given URL contains all allowed special chars: . : / - _ ? = & @ % + #
+ * @given URL contains all allowed special chars (path/query/fragment): . : / - _ ? = & @ % + #
  * @when ocpp_validate_backend_url is called
  * @then Returns OCPP_VALIDATE_OK
+ * @note `@` moved from the authority to the path segment because the H-4
+ *       SSRF hardening now rejects embedded `user@host` userinfo in the
+ *       authority. `@` is still permitted elsewhere in the URL.
  */
 void test_url_valid_special_chars_accepted(void) {
     TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_OK,
-        ocpp_validate_backend_url("ws://user@host.com:8080/path-name_ok?a=1&b=2#frag+%20"));
+        ocpp_validate_backend_url("ws://host.com:8080/path-name_ok?a=1&b=2#frag+%20@tag"));
 }
 
 /*
@@ -314,6 +317,132 @@ void test_auth_key_empty_accepted(void) {
         ocpp_validate_auth_key(""));
 }
 
+/* ---- Security H-4: SSRF hardening of backend URL validator ---- */
+
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-H4-001
+ * @scenario Loopback IPv4 127.0.0.1 rejected
+ */
+void test_url_loopback_127_0_0_1_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_SSRF_LOOPBACK,
+        ocpp_validate_backend_url("wss://127.0.0.1/ocpp"));
+}
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-H4-001
+ * @scenario Any 127.x loopback rejected (covers 127.42.0.1 etc.)
+ */
+void test_url_loopback_127_any_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_SSRF_LOOPBACK,
+        ocpp_validate_backend_url("ws://127.42.9.7:8080/"));
+}
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-H4-001
+ * @scenario localhost hostname rejected
+ */
+void test_url_loopback_localhost_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_SSRF_LOOPBACK,
+        ocpp_validate_backend_url("wss://localhost/ocpp"));
+}
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-H4-001
+ * @scenario LOCALHOST uppercase rejected (case-insensitive host check)
+ */
+void test_url_loopback_localhost_uppercase_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_SSRF_LOOPBACK,
+        ocpp_validate_backend_url("wss://LOCALHOST:8443/"));
+}
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-H4-001
+ * @scenario 0.0.0.0 (bind-any / loopback alias) rejected
+ */
+void test_url_loopback_0_0_0_0_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_SSRF_LOOPBACK,
+        ocpp_validate_backend_url("ws://0.0.0.0/ocpp"));
+}
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-H4-001
+ * @scenario IPv6 loopback [::1] rejected
+ */
+void test_url_loopback_ipv6_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_SSRF_LOOPBACK,
+        ocpp_validate_backend_url("wss://[::1]/ocpp"));
+}
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-H4-002
+ * @scenario IPv4 link-local 169.254.x rejected (AutoIP / APIPA)
+ */
+void test_url_linklocal_ipv4_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_SSRF_LINK_LOCAL,
+        ocpp_validate_backend_url("wss://169.254.10.20:8443/"));
+}
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-H4-002
+ * @scenario IPv6 link-local fe80:: rejected
+ */
+void test_url_linklocal_ipv6_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_SSRF_LINK_LOCAL,
+        ocpp_validate_backend_url("wss://[fe80::1]/ocpp"));
+}
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-H4-003
+ * @scenario Embedded user:pass@host rejected
+ */
+void test_url_embedded_creds_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_EMBEDDED_CREDS,
+        ocpp_validate_backend_url("wss://user:pass@evil.example/ocpp"));
+}
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-H4-003
+ * @scenario Embedded @ in authority (even without colon) rejected
+ */
+void test_url_embedded_at_rejected(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_EMBEDDED_CREDS,
+        ocpp_validate_backend_url("ws://user@evil.example/ocpp"));
+}
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-H4-004
+ * @scenario @ inside path component is allowed (authority is clean)
+ */
+void test_url_at_in_path_allowed(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_OK,
+        ocpp_validate_backend_url("wss://ocpp.tapelectric.app/path/with@sign"));
+}
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-H4-005
+ * @scenario RFC1918 private ranges still allowed — many users self-host CSMS on LAN
+ */
+void test_url_rfc1918_private_still_allowed(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_OK,
+        ocpp_validate_backend_url("ws://192.168.1.10:8080/steve/"));
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_OK,
+        ocpp_validate_backend_url("ws://10.0.0.5/ocpp"));
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_OK,
+        ocpp_validate_backend_url("ws://172.20.0.1/"));
+}
+/*
+ * @feature OCPP Settings Validation
+ * @req REQ-OCPP-H4-005
+ * @scenario Normal public hostnames still allowed (regression-proof)
+ */
+void test_url_public_hostname_still_allowed(void) {
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_OK,
+        ocpp_validate_backend_url("wss://ocpp.tapelectric.app/CB123"));
+    TEST_ASSERT_EQUAL_INT(OCPP_VALIDATE_OK,
+        ocpp_validate_backend_url("wss://csms.example.com:8443/ocpp?id=42"));
+}
+
 /* ---- Main ---- */
 int main(void) {
     TEST_SUITE_BEGIN("OCPP Settings Validation");
@@ -341,6 +470,21 @@ int main(void) {
     RUN_TEST(test_auth_key_too_long);
     RUN_TEST(test_auth_key_exactly_40_accepted);
     RUN_TEST(test_auth_key_empty_accepted);
+
+    /* Security H-4 — SSRF hardening */
+    RUN_TEST(test_url_loopback_127_0_0_1_rejected);
+    RUN_TEST(test_url_loopback_127_any_rejected);
+    RUN_TEST(test_url_loopback_localhost_rejected);
+    RUN_TEST(test_url_loopback_localhost_uppercase_rejected);
+    RUN_TEST(test_url_loopback_0_0_0_0_rejected);
+    RUN_TEST(test_url_loopback_ipv6_rejected);
+    RUN_TEST(test_url_linklocal_ipv4_rejected);
+    RUN_TEST(test_url_linklocal_ipv6_rejected);
+    RUN_TEST(test_url_embedded_creds_rejected);
+    RUN_TEST(test_url_embedded_at_rejected);
+    RUN_TEST(test_url_at_in_path_allowed);
+    RUN_TEST(test_url_rfc1918_private_still_allowed);
+    RUN_TEST(test_url_public_hostname_still_allowed);
 
     TEST_SUITE_RESULTS();
 }


### PR DESCRIPTION
**Security fix H-4.** Harden \`ocpp_validate_backend_url()\` so it rejects SSRF targets (loopback, link-local) and embedded \`user:pass@host\` credentials. +13 unit tests.

## Why

Before this fix the validator only checked scheme + a character whitelist. It accepted every form below:

\`\`\`
wss://127.0.0.1:8443/ocpp                  — loopback → charger talks OCPP to itself
wss://localhost/ocpp                       — loopback by name
wss://0.0.0.0/ocpp                         — loopback alias
wss://[::1]/ocpp                           — IPv6 loopback
wss://169.254.10.20/ocpp                   — link-local / AutoIP
wss://[fe80::1]/ocpp                       — IPv6 link-local
wss://user:pass@evil.example/ocpp          — embedded credentials
\`\`\`

Combined with the unauthenticated \`POST /settings?ocpp_update=1&ocpp_backend_url=...\` path (tracked separately under the broader HTTP-auth gap), an attacker on the LAN can redirect the charger's OCPP session to an attacker-controlled CSMS, or point it at a local service only reachable from the charger.

## What the fix adds

Three new enum values + an authority-level check that runs before the existing character whitelist:

| Reject reason | Covers |
|---|---|
| \`OCPP_VALIDATE_SSRF_LOOPBACK\` | \`127.x.x.x\`, \`localhost\` (case-insensitive), \`0.0.0.0\`, \`::1\`, \`[::1]\` |
| \`OCPP_VALIDATE_SSRF_LINK_LOCAL\` | \`169.254.x.x\`, \`fe80::\` (with or without brackets, case-insensitive) |
| \`OCPP_VALIDATE_EMBEDDED_CREDS\` | Any \`@\` in the authority component. \`@\` still allowed in path. |

**Deliberately NOT blocked:** RFC1918 private ranges (10./8, 172.16-31./12, 192.168./16). Many users self-host a SteVe or equivalent CSMS on the LAN — blocking these would break a legitimate deployment.

## Caller update

\`http_handlers.cpp\` \`POST /settings?ocpp_update=1\` handler now emits dedicated error messages for the three new rejection reasons so the Web UI / REST client shows WHY a URL was refused:

- \`"URL must not contain embedded user:pass@ credentials"\`
- \`"URL must not point to the charger itself (loopback / 127.x / ::1)"\`
- \`"URL must not point to link-local (169.254.x / fe80::)"\`

## Tests

**13 new unit tests** (REQ-OCPP-H4-001..005) in \`test_ocpp_settings.c\`:

- Loopback variants (6 tests): IPv4 127.0.0.1, any 127.x, localhost, LOCALHOST, 0.0.0.0, IPv6 [::1]
- Link-local variants (2): IPv4 169.254.x, IPv6 [fe80::1]
- Embedded creds (2): \`user:pass@\` and bare \`user@\`
- Regression-proof (3): \`@\` in path allowed, RFC1918 still allowed, public hostname still allowed

**1 existing test updated:** \`test_url_valid_special_chars_accepted\` used \`user@host.com\` in the authority — that form is exactly what H-4 rejects, so the \`@\` was moved to the path fragment. Semantic shift is intentional.

Total OCPP-settings suite: **36 tests pass** (up from 23).

## Verification

- Native tests (all 51 suites): pass
- ESP32 release build: SUCCESS

## Test plan

- [x] Full 5-step verification locally
- [x] Pre-existing OCPP tests still pass
- [ ] **On-device:** try to set \`ocpp_backend_url=wss://127.0.0.1/ocpp\` via Web UI → verify error message explains the rejection
- [ ] **On-device:** verify an RFC1918 URL (e.g. \`ws://192.168.1.10:8080/steve\`) still saves successfully

## Related

- Security review finding **H-4**.
- The broader \`POST /settings\` should also gain authentication — tracked separately in the security review as Critical/High items for a unified auth layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)