### PR TITLE
security(M-3, M-4): firmware_manager validate_sig — full partition erase + zero hash

### DIFF
--- a/SmartEVSE-3/src/firmware_manager.cpp
+++ b/SmartEVSE-3/src/firmware_manager.cpp
@@ -227,15 +227,28 @@ bool validate_sig( const esp_partition_t* partition, unsigned char *signature, i
         }
     }
 
+    // SECURITY M-3: zero the hash buffer before freeing so the fingerprint
+    // of the firmware we just validated does not linger in heap. Cheap
+    // defense-in-depth — hash is not itself secret but keeps debug-memory
+    // dumps from trivially revealing it.
+    if (hash) {
+        memset( hash, 0, mdinfo->size );
+    }
     free( hash );
 
     if( verified ) {
         return true;
     }
 
-    // All keys failed — overwrite the first few bytes so this partition won't boot!
-    log_w( "Validation failed (tried %u keys), erasing the invalid partition.\n", (unsigned)NUM_TRUSTED_KEYS);
-    ESP.partitionEraseRange( partition, 0, ENCRYPTED_BLOCK_SIZE);
+    // SECURITY M-4: all keys failed — erase the ENTIRE partition, not just
+    // the first ENCRYPTED_BLOCK_SIZE. The previous narrow erase only
+    // invalidated the boot header. If a reset happened during the next
+    // chargepoint update (or if the bootloader ever tolerated a missing
+    // header), the remaining >4KB of attacker bytes could still be
+    // observed or executed. Full partition erase is the safe default.
+    log_w( "Validation failed (tried %u keys), erasing the full invalid partition (%u bytes).\n",
+           (unsigned)NUM_TRUSTED_KEYS, (unsigned)partition->size);
+    ESP.partitionEraseRange( partition, 0, partition->size );
     return false;
 }
 


### PR DESCRIPTION
Two small hardenings to \`firmware_manager.cpp::validate_sig()\` from the security review.

## M-4 — erase the full partition on signature failure (main fix)

On a signature mismatch the old code erased only the first \`ENCRYPTED_BLOCK_SIZE\` (4 KB):

\`\`\`cpp
ESP.partitionEraseRange(partition, 0, ENCRYPTED_BLOCK_SIZE);
\`\`\`

That invalidates the boot header but leaves the remaining attacker bytes in flash. If a reset happens during the next update attempt (or if a bootloader ever tolerated a missing header), those bytes could become observable or executable. The parent \`forceUpdate()\` path (lines 380-393) already erased the full partition on failure — so in the web-UI flow the safety was present. This fix keeps both paths aligned and covers any direct caller of \`validate_sig()\`:

\`\`\`cpp
ESP.partitionEraseRange(partition, 0, partition->size);
\`\`\`

## M-3 — zero the SHA-256 hash buffer before free (hygiene)

\`\`\`cpp
if (hash) memset(hash, 0, mdinfo->size);
free(hash);
\`\`\`

The firmware-image hash is not secret, but memset-before-free keeps debug-memory dumps from trivially revealing which firmware was just validated. Cheap defense-in-depth.

## Verification

- Native tests: 51 suites, all pass
- ESP32 release build: SUCCESS
- No pure-C test for \`validate_sig()\` — the function is ESP-IDF / Arduino only. The changes are narrow and covered by static analysis (\`partition->size\` is a standard ESP-IDF field).

## Related

- Security review findings **M-3** and **M-4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)