### PR TITLE
security(C-2): never return OCPP auth_key via /settings GET

### DIFF
--- a/SmartEVSE-3/data/app.js
+++ b/SmartEVSE-3/data/app.js
@@ -674,7 +674,13 @@ function loadData() {
                 if (!ocppEditMode) {
                     $id('ocpp_backend_url').value = data.ocpp.backend_url;
                     $id('ocpp_cb_id').value = data.ocpp.cb_id;
-                    $id('ocpp_auth_key').value = data.ocpp.auth_key;
+                    /* Security C-2: backend no longer returns the plaintext auth_key;
+                     * it sends auth_key_set: bool instead. Show a placeholder so the
+                     * user knows a key is configured without exposing it. */
+                    $id('ocpp_auth_key').value = data.ocpp.auth_key_set ? '••••••••' : '';
+                    $id('ocpp_auth_key').placeholder = data.ocpp.auth_key_set
+                        ? 'Auth key configured (enter new value to replace)'
+                        : 'Only for SP2 connections';
                     $id('ocpp_auto_auth_idtag').value = data.ocpp.auto_auth_idtag;
                 }
 
@@ -802,9 +808,16 @@ function configureOcpp() {
         ocpp_update:          1,
         ocpp_backend_url:     $id('ocpp_backend_url').value,
         ocpp_cb_id:           $id('ocpp_cb_id').value,
-        ocpp_auth_key:        $id('ocpp_auth_key').value,
         ocpp_auto_auth_idtag: $id('ocpp_auto_auth_idtag').value
     };
+    /* Security C-2: only include ocpp_auth_key when the user actually typed a
+     * new value. The displayed placeholder '••••••••' is a stand-in for the
+     * configured-but-hidden key — sending it back would overwrite the real
+     * secret with bullets. Skip the field if it's empty or still the placeholder. */
+    var key = $id('ocpp_auth_key').value;
+    if (key && key !== '••••••••') {
+        params.ocpp_auth_key = key;
+    }
     var query = Object.keys(params)
         .map(function(k) { return k + "=" + encodeURIComponent(params[k]); })
         .join("&");

--- a/SmartEVSE-3/src/http_handlers.cpp
+++ b/SmartEVSE-3/src/http_handlers.cpp
@@ -301,7 +301,14 @@ bool handle_URI(struct mg_connection *c, struct mg_http_message *hm,  webServerR
         doc["ocpp"]["mode"] = OcppMode ? "Enabled" : "Disabled";
         doc["ocpp"]["backend_url"] = OcppWsClient ? OcppWsClient->getBackendUrl() : "";
         doc["ocpp"]["cb_id"] = OcppWsClient ? OcppWsClient->getChargeBoxId() : "";
-        doc["ocpp"]["auth_key"] = OcppWsClient ? OcppWsClient->getAuthKey() : "";
+        // SECURITY C-2: never return the OCPP auth_key (basic-auth password) to
+        // any client. Mirror the mqtt.password_set pattern — caller can tell if
+        // a key is configured without being able to read it. Before this fix
+        // any LAN client calling GET /settings obtained the plaintext key.
+        {
+            const char *ak = OcppWsClient ? OcppWsClient->getAuthKey() : "";
+            doc["ocpp"]["auth_key_set"] = (ak != NULL && ak[0] != '\0');
+        }
 
         {
             auto freevendMode = MicroOcpp::getConfigurationPublic(MO_CONFIG_EXT_PREFIX "FreeVendActive");

--- a/docs/upstream-differences.md
+++ b/docs/upstream-differences.md
@@ -184,6 +184,12 @@ Findings from the security review (see internal report; most issues are inherite
 | Fix | Why | Details |
 |-----|-----|---------|
 | Unsigned firmware upload rejected at `POST /update` | Upstream accepts `firmware.bin` / `firmware.debug.bin` uploads over unauthenticated HTTP with no signature check → any LAN client can flash arbitrary firmware (unauthenticated RCE). Fork accepts only `*.signed.bin` — verified via the multi-key RSA validator from PR #125 | Security fix C-1 |
+| OCPP auth_key never exposed via `/settings` GET | Upstream returns the plaintext OCPP backend basic-auth key to any client calling `GET /settings`. Fork emits only `auth_key_set: bool` and the Web UI shows a placeholder | Security fix C-2 |
+| MQTT private password redacted from boot log | Upstream logs the full EC-private-key-hash on every boot. Fork logs a 4-char prefix then `[redacted]` | Security fix C-5 |
+| `strncpy(RequiredEVCCID, ...)` always NUL-terminated | Upstream pattern leaves the buffer unterminated when source fills it; subsequent `%s` walks past end | Security fix H-5 |
+| OCPP URL validator rejects SSRF targets | Upstream accepts `wss://127.0.0.1/`, `wss://[::1]/`, `wss://169.254.x/`, `wss://user:pass@host/`. Fork rejects loopback + link-local + embedded credentials. RFC1918 still allowed for self-hosted CSMS | Security fix H-4 |
+| Full partition erase on signature failure | Upstream erases only the first `ENCRYPTED_BLOCK_SIZE` (4 KB) on sig-fail, leaving >4 KB of attacker bytes in flash. Fork erases the entire partition | Security fix M-4 |
+| Hash buffer zeroed before free in `validate_sig` | Hygiene: keeps debug-memory dumps from trivially revealing the firmware fingerprint | Security fix M-3 |
 
 ---
 


### PR DESCRIPTION
Security fix **C-2**. \`GET /settings\` previously returned the OCPP backend basic-auth key in plaintext to any LAN client. This PR replaces the field with \`auth_key_set: bool\` (mirrors \`mqtt.password_set\`).

## Why it matters

\`GET /settings\` is unauthenticated. Anyone on the home LAN — an ambient IoT device, a guest's laptop — could scrape the OCPP auth key and impersonate the charger at the CSMS, capture transactions, or forge billing.

## Changes

**Backend** (\`http_handlers.cpp\`):
\`\`\`cpp
// was: doc["ocpp"]["auth_key"] = OcppWsClient->getAuthKey();
doc["ocpp"]["auth_key_set"] = (ak != NULL && ak[0] != '\0');
\`\`\`

**Web UI** (\`app.js\`):
- Shows \`••••••••\` placeholder when a key is configured (so user sees it's set without reading the value)
- On save: only sends \`ocpp_auth_key\` parameter if the user typed a new value — prevents overwriting the real key with bullets when clicking Save without changing anything

## Docs

\`docs/upstream-differences.md\` — added C-2 to the Security Hardening table, plus backfill of C-5/H-5/H-4/M-3/M-4 rows for the already-merged fixes.

## Verification

- Native tests: 51 suites, all pass
- ESP32 release build: SUCCESS

## Upstream

Inherited finding from \`dingo35\`. Fix is unilateral on the fork. Private upstream advisory covering the broader set of inherited vulnerabilities is being drafted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)