### PR TITLE
fix: remove SetCPDuty readback check (false-positive MISMATCH)

### DIFF
--- a/SmartEVSE-3/src/main.cpp
+++ b/SmartEVSE-3/src/main.cpp
@@ -716,12 +716,6 @@ void SetCPDuty(uint32_t DutyCycle){
 #else //CH32 and v3 ESP32
 #if SMARTEVSE_VERSION >=30 && SMARTEVSE_VERSION < 40 //v3 ESP32
     ledcWrite(CP_CHANNEL, DutyCycle);                                       // update PWM signal
-#if DIAG_LOG
-    uint32_t readback = ledcRead(CP_CHANNEL);
-    if (readback != DutyCycle) {
-        _LOG_A("SetCPDuty MISMATCH: wrote %u, read %u\n", DutyCycle, readback);
-    }
-#endif
 #endif
 #ifndef SMARTEVSE_VERSION  //CH32
     // update PWM signal


### PR DESCRIPTION
## Summary
- Remove the `ledcRead(CP_CHANNEL)` sanity check after `ledcWrite` in `SetCPDuty` (main.cpp:719–724, under `DIAG_LOG`).
- The check was a false alarm: ESP32 LEDC latches the new duty at the next PWM period boundary (~1 ms at 1 kHz CP), but `ledcRead` returns the currently-latched value. Every duty change therefore logged `SetCPDuty MISMATCH: wrote <new>, read <old>`.

## Evidence from field logs
Two back-to-back sessions on firmware `bbb827d` logged the following while the vehicle **was charging correctly at 3×14 A**:
```
(SetCurrent)(C0) SetCurrent(130) duty=221
(SetCPDuty)(C0) SetCPDuty MISMATCH: wrote 221, read 102
```
`102` is the previous 6 A-offer duty. The car then pulled CP to state C and drew the full 13 A offer — only possible if the PWM actually moved to duty 221. The readback log is therefore misleading and creates false bug reports.

## Test plan
- [x] `make clean test` — 51/51 suites, 1,096 tests pass
- [x] AddressSanitizer + UBSan — 51/51 pass
- [x] cppcheck (matches CI config) — clean
- [x] `pio run -e release` (v3 ESP32) — builds (RAM 24.0%, Flash 86.5%)
- [x] CH32/v4 — local build fails on unrelated path-with-spaces issue in `gen_ldscript.py`; CI should build cleanly. Change is inside `#if SMARTEVSE_VERSION >=30 && SMARTEVSE_VERSION < 40`, so CH32 and v4 code paths are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)