### PR TITLE
fix(diag): diag_stop must reset ring->profile to OFF, not just freeze

### DIFF
--- a/SmartEVSE-3/src/diag_sampler.cpp
+++ b/SmartEVSE-3/src/diag_sampler.cpp
@@ -83,6 +83,15 @@ void diag_start(diag_profile_t profile)
 
 void diag_stop(void)
 {
+    /* Reset the profile to OFF so /diag/status reports the capture as
+     * stopped. Without this the ring stays "general/solar/loadbal/..."
+     * (just frozen), and the web UI's auto-resume on page load
+     * (app.js: `if (d.profile && d.profile !== 'off') diagConnectWs()`)
+     * keeps re-attaching the WebSocket after every Stop press until
+     * the device reboots and diag_sampler_init() clears the ring.
+     * Freeze stays for symmetry — diag_start()'s diag_ring_reset()
+     * clears it back to false on the next capture. */
+    diag_set_profile(&diag_ring, DIAG_PROFILE_OFF);
     diag_ring_freeze(&diag_ring, true);
     diag_mb_enable(&g_diag_mb_ring, false);
 }


### PR DESCRIPTION
## Summary

Pressing **Stop** in the diagnostics panel didn't stop it — every page reload re-attached the WebSocket and the badge showed "Capturing" again. Only an EVSE reboot cleared the state.

## Root cause

\`diag_stop()\` in \`diag_sampler.cpp:84\` froze the ring (no new samples written) and disabled Modbus event capture, but **never updated \`ring->profile\`**. \`/diag/status\` reports the profile from \`ring.profile\`, so the backend kept replying \`{"profile":"general"…}\` after Stop. The frontend's auto-resume in \`app.js:1042\`:

\`\`\`js
if (d && d.profile && d.profile !== 'off') diagConnectWs();
\`\`\`

…then re-attached the WebSocket on every page load.

Reboot worked because \`diag_sampler_init()\` calls \`diag_ring_init()\` which sets \`profile = DIAG_PROFILE_OFF\`.

## Fix

One-line addition to \`diag_stop()\`: also call \`diag_set_profile(&diag_ring, DIAG_PROFILE_OFF)\`. Keep the freeze + Modbus-disable for symmetry; \`diag_ring_reset()\` inside \`diag_start()\` clears the frozen flag back to false on the next capture.

## Verification

- Native tests: 52/52 pass
- v3 debug build: OK
- No native tests directly cover \`diag_stop()\` (it's in \`diag_sampler.cpp\` under \`#if defined(SMARTEVSE_VERSION)\` — ESP32 glue layer). The underlying invariant — \`ring->profile == OFF\` rejects pushes — is already covered by \`test_diag_telemetry.c::test_profile_off_rejects_push\`.

## On-device verification (after flash)

1. Press Start, see capture rolling.
2. Press Stop.
3. Reload the page.
4. Badge should now show "Stopped" / no capture, no auto-resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)