### PR TITLE
security(SEC-MQTT-KEEP): MQTT POST empty/bullets password preserves stored value

### DIFF
--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -1831,9 +1831,21 @@ static void fn_http_server(struct mg_connection *c, int ev, void *ev_data) {
                 }
 
                 if(request->hasParam("mqtt_password")) {
-                    MQTTpassword = request->getParam("mqtt_password")->value();
-                    if (!MQTTpassword || MQTTpassword == "") {
-                        MQTTpassword.clear();
+                    /* SECURITY SEC-MQTT-KEEP (task #38): empty and the bullets
+                     * placeholder both mean "keep the existing password" —
+                     * previously an empty value wiped MQTTpassword, which
+                     * combined with GET /settings returning only password_set
+                     * (never the password itself, by Security C-2 intent) made
+                     * any non-UI client that re-POSTed the form lose the
+                     * password. The Web UI already skips the field on empty
+                     * save; this is defense-in-depth for curl / Postman / HA
+                     * REST integrations. Symmetric with ocpp_validate_auth_key
+                     * accepting empty + MicroOcpp preserving the stored value. */
+                    String newPwd = request->getParam("mqtt_password")->value();
+                    if (newPwd.length() > 0 && newPwd != "••••••••") {
+                        MQTTpassword = newPwd;
+                    } else {
+                        _LOG_A("MQTT password POST empty/placeholder — preserving stored value\n");
                     }
                     doc["mqtt_password_set"] = (MQTTpassword != "");
                 }


### PR DESCRIPTION
## Summary

Backend defense-in-depth for the MQTT password wipe bug. Symmetric with the OCPP \`auth_key\` handling.

**Before**: \`POST /settings?mqtt_update=1&mqtt_password=\` wiped the stored \`MQTTpassword\`. Because GET \`/settings\` returns only \`password_set:bool\` (never the password, by design), any non-UI client that round-tripped the form lost the password silently.

**After**: an empty string or the \`••••••••\` placeholder is treated as "keep existing". Only non-empty, non-placeholder values overwrite the stored password. Mirrors OCPP's \`ocpp_validate_auth_key\` accepting empty + MicroOcpp library preserving the stored key.

## Why

The UI (PR #152) already defends the browser flow by omitting the field on empty save, so normal users never hit this. The backend exposure was still real for:

- \`curl -X POST\` integrations.
- Home Assistant REST commands that POST the settings payload.
- Postman collections / ad-hoc scripts.

Any of these that round-trip the form without knowing to omit the password field would wipe it.

## Trade-off

Removes the undocumented "clear password by POSTing empty" path. For the rare case where an admin actually wants to revert to anonymous MQTT, \`/erasesettings\` or the LCD menu still work. Accidental wipes were strictly more common than intentional clears. An explicit \`mqtt_password_clear=1\` param could be added in a follow-up if the dedicated clear action is ever needed.

## Scope

One function in \`SmartEVSE-3/src/network_common.cpp\` (inside the POST \`/settings\` handler). No API additions, no new NVS keys, no UI changes.

## Verification

- Native tests: 52/52 pass.
- \`pio run -e release\`: OK.

Closes task #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)