### PR TITLE
feat(plan-16 phase 2): rate-limit /lcd-verify-password with escalating backoff

### DIFF
--- a/SmartEVSE-3/src/http_handlers.cpp
+++ b/SmartEVSE-3/src/http_handlers.cpp
@@ -27,6 +27,7 @@
 #include <MicroOcpp/Core/Configuration.h>
 #include "ocpp_logic.h"
 #include "http_auth.h"          // Plan 16 Phase 1 — HTTP auth decision (pure C)
+#include "pin_rate_limit.h"     // Plan 16 Phase 2 — brute-force limiter for /lcd-verify-password
 #include "ocpp_telemetry.h"
 #endif //ENABLE_OCPP
 
@@ -1162,6 +1163,26 @@ bool handle_URI(struct mg_connection *c, struct mg_http_message *hm,  webServerR
         return true;
 
     } else if (mg_http_match_uri(hm, "/lcd-verify-password") && !memcmp("POST", hm->method.buf, hm->method.len)) {
+        /* Plan 16 Phase 2 — brute-force limiter. Single global counter
+         * (not per-IP) sized to the LAN trust model in the design doc.
+         * On cooldown, return 429 Retry-After and do NOT attempt the PIN
+         * compare — a timing side-channel here would let an attacker keep
+         * probing around the rate limit. */
+        static pin_rate_limit_t g_pin_rl = {0};
+        uint32_t now = (uint32_t)millis();
+        if (pin_rl_check(&g_pin_rl, now) == PIN_RL_DENY_COOLDOWN) {
+            uint32_t retry = pin_rl_retry_after_seconds(&g_pin_rl, now);
+            char hdr[96];
+            snprintf(hdr, sizeof(hdr),
+                     "Content-Type: application/json\r\nRetry-After: %u\r\n",
+                     (unsigned)retry);
+            mg_http_reply(c, 429, hdr,
+                          "{\"success\":false,\"rate_limited\":true,"
+                          "\"retry_after\":%u}\r\n",
+                          (unsigned)retry);
+            return true;
+        }
+
         char password[32];
         mg_http_get_var(&hm->body, "password", password, sizeof(password));
         DynamicJsonDocument doc(256);
@@ -1174,9 +1195,11 @@ bool handle_URI(struct mg_connection *c, struct mg_http_message *hm,  webServerR
              * treats ts==0 as "never set" and would skip expiration. */
             uint32_t ts = (uint32_t)millis();
             LCDPasswordOkSince = (ts == 0) ? 1 : ts;
+            pin_rl_record_success(&g_pin_rl);   // Phase 2
             doc["success"] = true;
         } else {
             LCDPasswordOkSince = 0;
+            pin_rl_record_failure(&g_pin_rl, now);  // Phase 2
             doc["success"] = false;
         }
 

--- a/SmartEVSE-3/src/pin_rate_limit.c
+++ b/SmartEVSE-3/src/pin_rate_limit.c
@@ -1,0 +1,88 @@
+/*
+ * pin_rate_limit.c — Rate limiter impl. See pin_rate_limit.h.
+ */
+#include "pin_rate_limit.h"
+
+/* Escalating cooldown schedule, in milliseconds. Index = fail_count,
+ * capped at the last entry once the counter grows beyond the table. */
+static const uint32_t kCooldownMs[] = {
+    0,                              /* 0 — never reached via record_failure */
+    0,                              /* 1 — free */
+    0,                              /* 2 — free */
+    10UL * 1000UL,                  /* 3 — 10 s */
+    60UL * 1000UL,                  /* 4 — 60 s */
+    300UL * 1000UL,                 /* 5 — 5 min */
+    1800UL * 1000UL                 /* 6+ — 30 min (cap) */
+};
+#define PIN_RL_MAX_INDEX ((uint16_t)(sizeof(kCooldownMs) / sizeof(kCooldownMs[0]) - 1))
+
+static uint32_t cooldown_for_count(uint16_t fail_count) {
+    if (fail_count > PIN_RL_MAX_INDEX) fail_count = PIN_RL_MAX_INDEX;
+    return kCooldownMs[fail_count];
+}
+
+pin_rl_result_t pin_rl_check(pin_rate_limit_t *state, uint32_t now_ms) {
+    if (!state) return PIN_RL_ALLOW;    /* Fail-open on bad arg — testable. */
+
+    /* Long-idle auto-reset: if the last attempt (success or failure) was
+     * more than PIN_RL_IDLE_RESET_MS ago, wipe the fail history so a
+     * legitimate user coming back hours later gets a clean slate. Do NOT
+     * auto-reset while an active cooldown is still in effect — that would
+     * defeat the purpose of the cooldown. */
+    if (state->cooldown_until_ms == 0 && state->last_attempt_ms != 0 &&
+        (now_ms - state->last_attempt_ms) >= PIN_RL_IDLE_RESET_MS) {
+        state->fail_count = 0;
+    }
+
+    if (state->cooldown_until_ms != 0) {
+        /* Cooldown active — still holding? Unsigned wrap-safe compare:
+         * (now - until) has the high bit set iff now < until. */
+        if ((int32_t)(now_ms - state->cooldown_until_ms) < 0) {
+            return PIN_RL_DENY_COOLDOWN;
+        }
+        /* Cooldown elapsed. Clear the sentinel so the next failure
+         * re-arms from the current fail_count. */
+        state->cooldown_until_ms = 0;
+    }
+
+    return PIN_RL_ALLOW;
+}
+
+void pin_rl_record_success(pin_rate_limit_t *state) {
+    if (!state) return;
+    state->fail_count = 0;
+    state->cooldown_until_ms = 0;
+    /* Keep last_attempt_ms so the idle-reset logic doesn't fire
+     * spuriously on the next check. Not strictly needed (success
+     * already clears fail_count) but keeps state consistent. */
+}
+
+void pin_rl_record_failure(pin_rate_limit_t *state, uint32_t now_ms) {
+    if (!state) return;
+
+    state->last_attempt_ms = now_ms;
+
+    /* Saturate at UINT16_MAX to avoid wrap; the cooldown is capped at
+     * kCooldownMs[max] regardless, so stopping the counter here is safe. */
+    if (state->fail_count < 0xFFFFu) {
+        state->fail_count++;
+    }
+
+    uint32_t cd = cooldown_for_count(state->fail_count);
+    if (cd > 0) {
+        state->cooldown_until_ms = now_ms + cd;
+        /* Guard the zero-sentinel: if millis() wrapped such that
+         * now_ms + cd == 0 exactly, bump by 1 so "cooldown active" is
+         * distinguishable from "never armed". */
+        if (state->cooldown_until_ms == 0) state->cooldown_until_ms = 1;
+    }
+}
+
+uint32_t pin_rl_retry_after_seconds(const pin_rate_limit_t *state,
+                                    uint32_t now_ms) {
+    if (!state || state->cooldown_until_ms == 0) return 0;
+    int32_t delta = (int32_t)(state->cooldown_until_ms - now_ms);
+    if (delta <= 0) return 0;
+    /* Round up to whole seconds so Retry-After never under-reports. */
+    return (uint32_t)((delta + 999) / 1000);
+}

--- a/SmartEVSE-3/src/pin_rate_limit.h
+++ b/SmartEVSE-3/src/pin_rate_limit.h
@@ -1,0 +1,89 @@
+/*
+ * pin_rate_limit.h — Rate limiter for the /lcd-verify-password endpoint.
+ *
+ * Plan 16 Phase 2. Prevents brute-force of the 4-digit LCD PIN.
+ *
+ * Design:
+ *   Pure C, no allocation, no platform deps — testable natively.
+ *   Tracks consecutive failed attempts in a single struct. After a
+ *   threshold, imposes an escalating cooldown during which further
+ *   POSTs to /lcd-verify-password are rejected with 429 Retry-After.
+ *   Successful verification resets the counter.
+ *
+ * Threat model:
+ *   LAN attacker scripting POSTs to /lcd-verify-password, 4-digit
+ *   PIN = 10,000 combinations. With this limiter, worst-case time
+ *   to exhaust the space is on the order of months (see PR body
+ *   for math), defeating practical brute-force.
+ *
+ * Non-goals:
+ *   Per-source-IP tracking (global counter only, embedded RAM budget).
+ *   Protection against distributed/parallel attacks (LAN trust model).
+ */
+#ifndef PIN_RATE_LIMIT_H
+#define PIN_RATE_LIMIT_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Internal state. Caller allocates (typically file-scope static).
+ * Initialise with zero — {0} is a valid "no history" state.
+ */
+typedef struct {
+    uint16_t fail_count;          /* Consecutive failed attempts (unbounded). */
+    uint32_t last_attempt_ms;     /* millis() of last POST, 0 = never. */
+    uint32_t cooldown_until_ms;   /* millis() when cooldown expires, 0 = none. */
+} pin_rate_limit_t;
+
+typedef enum {
+    PIN_RL_ALLOW          = 0,    /* Accept the attempt. */
+    PIN_RL_DENY_COOLDOWN  = 1     /* Reject with 429; caller reads retry_after. */
+} pin_rl_result_t;
+
+/* Reset counter when idle for this long (successful users shouldn't be
+ * penalised for a stale failure from hours ago). */
+#define PIN_RL_IDLE_RESET_MS  (10UL * 60UL * 1000UL)   /* 10 minutes */
+
+/*
+ * Check whether the current attempt is allowed. Does NOT mutate state
+ * other than auto-resetting the fail counter after long idle. After
+ * verification the caller MUST call pin_rl_record_success() or
+ * pin_rl_record_failure() to keep the counter up to date.
+ */
+pin_rl_result_t pin_rl_check(pin_rate_limit_t *state, uint32_t now_ms);
+
+/*
+ * Record a successful PIN verification — clears the counter and
+ * cooldown so the legitimate operator isn't penalised by past failures.
+ */
+void pin_rl_record_success(pin_rate_limit_t *state);
+
+/*
+ * Record a failed PIN verification — increments the counter and, once
+ * past the first free attempts, arms an escalating cooldown window.
+ * Backoff schedule (measured in seconds from now_ms):
+ *     fail_count <= 2            : no cooldown
+ *     fail_count == 3            : 10 s
+ *     fail_count == 4            : 60 s
+ *     fail_count == 5            : 300 s  (5 min)
+ *     fail_count >= 6            : 1800 s (30 min, cap)
+ */
+void pin_rl_record_failure(pin_rate_limit_t *state, uint32_t now_ms);
+
+/*
+ * Seconds remaining on the active cooldown. Returns 0 when no cooldown
+ * is active or it has already elapsed. Suitable for a Retry-After header.
+ */
+uint32_t pin_rl_retry_after_seconds(const pin_rate_limit_t *state,
+                                    uint32_t now_ms);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PIN_RATE_LIMIT_H */

--- a/SmartEVSE-3/test/native/Makefile
+++ b/SmartEVSE-3/test/native/Makefile
@@ -107,6 +107,9 @@ $(BUILD)/test_ocpp_resilience: $(TEST_DIR)/test_ocpp_resilience.c $(OCPP_LOGIC_S
 $(BUILD)/test_http_auth: $(TEST_DIR)/test_http_auth.c $(SRC_DIR)/http_auth.c $(SRC_DIR)/http_auth.h include/*.h | $(BUILD)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $(TEST_DIR)/test_http_auth.c $(SRC_DIR)/http_auth.c
 
+$(BUILD)/test_pin_rate_limit: $(TEST_DIR)/test_pin_rate_limit.c $(SRC_DIR)/pin_rate_limit.c $(SRC_DIR)/pin_rate_limit.h include/*.h | $(BUILD)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $(TEST_DIR)/test_pin_rate_limit.c $(SRC_DIR)/pin_rate_limit.c
+
 $(BUILD)/test_solar_debug_json: $(TEST_DIR)/test_solar_debug_json.c $(SOLAR_DEBUG_JSON_SRC) $(SRC_DIR)/solar_debug_json.h include/*.h | $(BUILD)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $(TEST_DIR)/test_solar_debug_json.c $(SOLAR_DEBUG_JSON_SRC)
 

--- a/SmartEVSE-3/test/native/tests/test_pin_rate_limit.c
+++ b/SmartEVSE-3/test/native/tests/test_pin_rate_limit.c
@@ -1,0 +1,255 @@
+/*
+ * test_pin_rate_limit.c — tests for the LCD-PIN brute-force limiter.
+ * See src/pin_rate_limit.h and docs/security/plan-16-http-auth-layer.md.
+ */
+
+#include "test_framework.h"
+#include "pin_rate_limit.h"
+#include <string.h>
+
+/* ---- Baseline: clean state lets requests through ---- */
+
+/*
+ * @feature PIN Rate Limit
+ * @req REQ-AUTH-020
+ * @scenario Clean state allows the first request
+ * @given A zero-initialised pin_rate_limit_t
+ * @when pin_rl_check is called
+ * @then Returns ALLOW
+ */
+void test_pin_rl_clean_state_allows(void) {
+    pin_rate_limit_t s = {0};
+    TEST_ASSERT_EQUAL_INT(PIN_RL_ALLOW, pin_rl_check(&s, 1000));
+}
+
+/*
+ * @feature PIN Rate Limit
+ * @req REQ-AUTH-020
+ * @scenario First two failures do not trigger cooldown
+ * @given A clean rate limiter
+ * @when Two consecutive failures are recorded
+ * @then pin_rl_check still returns ALLOW (no cooldown armed)
+ */
+void test_pin_rl_first_two_failures_free(void) {
+    pin_rate_limit_t s = {0};
+    pin_rl_record_failure(&s, 1000);
+    TEST_ASSERT_EQUAL_INT(PIN_RL_ALLOW, pin_rl_check(&s, 1100));
+    pin_rl_record_failure(&s, 1200);
+    TEST_ASSERT_EQUAL_INT(PIN_RL_ALLOW, pin_rl_check(&s, 1300));
+}
+
+/* ---- Escalating backoff schedule ---- */
+
+/*
+ * @feature PIN Rate Limit
+ * @req REQ-AUTH-021
+ * @scenario Third failure arms a 10-second cooldown
+ * @given Two failures already recorded
+ * @when A third failure is recorded and check is called immediately
+ * @then check returns DENY_COOLDOWN and retry_after ~= 10 s
+ */
+void test_pin_rl_third_failure_10s_cooldown(void) {
+    pin_rate_limit_t s = {0};
+    pin_rl_record_failure(&s, 1000);
+    pin_rl_record_failure(&s, 1100);
+    pin_rl_record_failure(&s, 1200);
+
+    TEST_ASSERT_EQUAL_INT(PIN_RL_DENY_COOLDOWN, pin_rl_check(&s, 1200));
+    uint32_t retry = pin_rl_retry_after_seconds(&s, 1200);
+    TEST_ASSERT_EQUAL_INT(10, (int)retry);
+}
+
+/*
+ * @feature PIN Rate Limit
+ * @req REQ-AUTH-021
+ * @scenario Fourth failure extends cooldown to 60 seconds
+ */
+void test_pin_rl_fourth_failure_60s_cooldown(void) {
+    pin_rate_limit_t s = {0};
+    for (int i = 0; i < 3; i++) pin_rl_record_failure(&s, 1000 + i * 100);
+    /* Assume attacker waits the 10 s out and tries again (now allowed). */
+    TEST_ASSERT_EQUAL_INT(PIN_RL_ALLOW, pin_rl_check(&s, 20000));
+    pin_rl_record_failure(&s, 20000);
+    TEST_ASSERT_EQUAL_INT(PIN_RL_DENY_COOLDOWN, pin_rl_check(&s, 20000));
+    TEST_ASSERT_EQUAL_INT(60, (int)pin_rl_retry_after_seconds(&s, 20000));
+}
+
+/*
+ * @feature PIN Rate Limit
+ * @req REQ-AUTH-021
+ * @scenario Fifth failure extends cooldown to 5 minutes
+ */
+void test_pin_rl_fifth_failure_5min_cooldown(void) {
+    pin_rate_limit_t s = {0};
+    for (int i = 0; i < 4; i++) pin_rl_record_failure(&s, i * 100);
+    pin_rl_record_failure(&s, 1000000);  /* far past any prior cooldown */
+    TEST_ASSERT_EQUAL_INT(PIN_RL_DENY_COOLDOWN, pin_rl_check(&s, 1000000));
+    TEST_ASSERT_EQUAL_INT(300, (int)pin_rl_retry_after_seconds(&s, 1000000));
+}
+
+/*
+ * @feature PIN Rate Limit
+ * @req REQ-AUTH-021
+ * @scenario Sixth and subsequent failures cap at 30 minutes
+ */
+void test_pin_rl_capped_at_30min(void) {
+    pin_rate_limit_t s = {0};
+    for (int i = 0; i < 10; i++) pin_rl_record_failure(&s, i * 100);
+    /* All 10 were recorded within the cooldown window so they each
+     * re-arm at the current count. Verify the final cap. */
+    s.cooldown_until_ms = 0;  /* force re-check of cap independent of timing */
+    pin_rl_record_failure(&s, 2000000);
+    TEST_ASSERT_EQUAL_INT(PIN_RL_DENY_COOLDOWN, pin_rl_check(&s, 2000000));
+    TEST_ASSERT_EQUAL_INT(1800, (int)pin_rl_retry_after_seconds(&s, 2000000));
+}
+
+/* ---- Cooldown elapses ---- */
+
+/*
+ * @feature PIN Rate Limit
+ * @req REQ-AUTH-022
+ * @scenario After cooldown elapses, new attempt is allowed
+ * @given A cooldown armed for 10 seconds at t=1000ms
+ * @when check is called at t=12000ms (11s later)
+ * @then check returns ALLOW and retry_after == 0
+ */
+void test_pin_rl_cooldown_elapses(void) {
+    pin_rate_limit_t s = {0};
+    pin_rl_record_failure(&s, 1000);
+    pin_rl_record_failure(&s, 1100);
+    pin_rl_record_failure(&s, 1200);   /* armed 10s cooldown at 1200ms */
+
+    TEST_ASSERT_EQUAL_INT(PIN_RL_DENY_COOLDOWN, pin_rl_check(&s, 5000));
+    TEST_ASSERT_EQUAL_INT(PIN_RL_ALLOW,         pin_rl_check(&s, 12000));
+    TEST_ASSERT_EQUAL_INT(0, (int)pin_rl_retry_after_seconds(&s, 12000));
+}
+
+/* ---- Retry-After reporting ---- */
+
+/*
+ * @feature PIN Rate Limit
+ * @req REQ-AUTH-023
+ * @scenario retry_after rounds up to whole seconds
+ * @given A 10s cooldown armed at t=1000
+ * @when queried at t=1500 (500ms in) it reports 10s, at t=9500 reports 1s
+ */
+void test_pin_rl_retry_after_rounding(void) {
+    pin_rate_limit_t s = {0};
+    pin_rl_record_failure(&s, 1000);
+    pin_rl_record_failure(&s, 1000);
+    pin_rl_record_failure(&s, 1000);     /* cooldown until 11000ms */
+
+    TEST_ASSERT_EQUAL_INT(10, (int)pin_rl_retry_after_seconds(&s, 1000));
+    TEST_ASSERT_EQUAL_INT(10, (int)pin_rl_retry_after_seconds(&s, 1500));
+    /* 500ms left → rounds up to 1s, not 0s. */
+    TEST_ASSERT_EQUAL_INT(1,  (int)pin_rl_retry_after_seconds(&s, 10500));
+    /* past cooldown → 0s */
+    TEST_ASSERT_EQUAL_INT(0,  (int)pin_rl_retry_after_seconds(&s, 11500));
+}
+
+/* ---- Success clears state ---- */
+
+/*
+ * @feature PIN Rate Limit
+ * @req REQ-AUTH-024
+ * @scenario Successful PIN resets counter and cooldown
+ * @given A state with an active cooldown after 3 failures
+ * @when pin_rl_record_success is called
+ * @then Subsequent checks ALLOW immediately and count is 0
+ */
+void test_pin_rl_success_clears_cooldown(void) {
+    pin_rate_limit_t s = {0};
+    for (int i = 0; i < 3; i++) pin_rl_record_failure(&s, 1000 + i * 100);
+    TEST_ASSERT_EQUAL_INT(PIN_RL_DENY_COOLDOWN, pin_rl_check(&s, 1500));
+
+    pin_rl_record_success(&s);
+
+    TEST_ASSERT_EQUAL_INT(PIN_RL_ALLOW, pin_rl_check(&s, 1500));
+    TEST_ASSERT_EQUAL_INT(0, (int)s.fail_count);
+    TEST_ASSERT_EQUAL_INT(0, (int)s.cooldown_until_ms);
+}
+
+/* ---- Long-idle auto-reset ---- */
+
+/*
+ * @feature PIN Rate Limit
+ * @req REQ-AUTH-025
+ * @scenario After idle > 10 min, counter auto-resets on next check
+ * @given 2 failures recorded (no cooldown yet)
+ * @when check is called more than 10 min later
+ * @then fail_count resets to 0 — no accidental lockout of returning users
+ */
+void test_pin_rl_idle_reset(void) {
+    pin_rate_limit_t s = {0};
+    pin_rl_record_failure(&s, 1000);
+    pin_rl_record_failure(&s, 1100);
+    TEST_ASSERT_EQUAL_INT(2, (int)s.fail_count);
+
+    /* 11 minutes later. */
+    uint32_t far = 1100 + (11UL * 60UL * 1000UL);
+    TEST_ASSERT_EQUAL_INT(PIN_RL_ALLOW, pin_rl_check(&s, far));
+    TEST_ASSERT_EQUAL_INT(0, (int)s.fail_count);
+}
+
+/*
+ * @feature PIN Rate Limit
+ * @req REQ-AUTH-025
+ * @scenario Idle-reset does not fire while a cooldown is still active
+ * @given Third failure arming a 10s cooldown
+ * @when check is called 11 minutes later — but the cooldown was only 10s
+ * @then Cooldown has long since elapsed, allow, but fail_count stays 3
+ *        (the cooldown was active AT SOME POINT after the idle window,
+ *         so idle-reset specifically does not trigger)
+ */
+void test_pin_rl_idle_reset_respects_cooldown(void) {
+    pin_rate_limit_t s = {0};
+    pin_rl_record_failure(&s, 1000);
+    pin_rl_record_failure(&s, 1100);
+    pin_rl_record_failure(&s, 1200);  /* 10s cooldown until 11200ms */
+    /* At t=11200 the cooldown is still armed, no reset; one millisecond
+     * later it is cleared but fail_count stays. */
+    uint32_t far = 1200 + (11UL * 60UL * 1000UL);
+    TEST_ASSERT_EQUAL_INT(PIN_RL_ALLOW, pin_rl_check(&s, far));
+    TEST_ASSERT_EQUAL_INT(3, (int)s.fail_count);
+}
+
+/* ---- Robustness / fail-open ---- */
+
+/*
+ * @feature PIN Rate Limit
+ * @req REQ-AUTH-026
+ * @scenario NULL state fails open (no crash, lets request through)
+ * @given A NULL pin_rate_limit_t pointer
+ * @when check / record_* / retry_after are called
+ * @then No crash; check returns ALLOW, retry_after returns 0
+ */
+void test_pin_rl_null_safe(void) {
+    TEST_ASSERT_EQUAL_INT(PIN_RL_ALLOW, pin_rl_check(NULL, 1000));
+    pin_rl_record_success(NULL);                /* must not crash */
+    pin_rl_record_failure(NULL, 1000);          /* must not crash */
+    TEST_ASSERT_EQUAL_INT(0, (int)pin_rl_retry_after_seconds(NULL, 1000));
+}
+
+int main(void) {
+    TEST_SUITE_BEGIN("PIN Rate Limit");
+
+    RUN_TEST(test_pin_rl_clean_state_allows);
+    RUN_TEST(test_pin_rl_first_two_failures_free);
+
+    RUN_TEST(test_pin_rl_third_failure_10s_cooldown);
+    RUN_TEST(test_pin_rl_fourth_failure_60s_cooldown);
+    RUN_TEST(test_pin_rl_fifth_failure_5min_cooldown);
+    RUN_TEST(test_pin_rl_capped_at_30min);
+
+    RUN_TEST(test_pin_rl_cooldown_elapses);
+    RUN_TEST(test_pin_rl_retry_after_rounding);
+
+    RUN_TEST(test_pin_rl_success_clears_cooldown);
+
+    RUN_TEST(test_pin_rl_idle_reset);
+    RUN_TEST(test_pin_rl_idle_reset_respects_cooldown);
+
+    RUN_TEST(test_pin_rl_null_safe);
+
+    TEST_SUITE_RESULTS();
+}


### PR DESCRIPTION
## Summary

Closes the remaining Plan 16 Phase 2 item: brute-force protection on the LCD-PIN verify endpoint. Phase 1 already shipped the Origin/CSRF check and 30-min session timeout; this PR adds the rate limiter.

## Design

New pure-C module \`pin_rate_limit.{c,h}\` — file-scope single counter, no per-IP tracking (matches the LAN trust model documented in the Phase 1 design doc).

Escalating cooldown:
- Failures 1–2: free
- Failure 3: 10 s cooldown
- Failure 4: 60 s
- Failure 5: 5 min
- Failure 6+: 30 min (capped)

Successful verification clears the counter and cooldown. An idle auto-reset (10 min) prevents legitimate operators from being locked out by stale failures; it does NOT bypass an active cooldown.

## Wiring

\`/lcd-verify-password\` now checks the limiter first. On cooldown, returns **429** with \`Retry-After: <seconds>\` and a JSON body, and **does not run the PIN compare** (avoids timing side-channel). On allowed attempts it runs the existing compare, then records success or failure.

## Brute-force math

10 000-PIN space, realistic attacker steady-state throughput is ~50 PINs/day once past the first few tiers. Full space: **~200 days** worst-case. Defeats scripted brute-force.

## Tests

12 SbE tests (REQ-AUTH-020 through 026) covering every tier, the cap, cooldown-elapses, retry-after rounding, success-clears, idle auto-reset semantics, and NULL-safety.

## Verification

- Native tests: 53/53 (was 52; +1 for \`test_pin_rate_limit\`)
- Sanitizers (ASan + UBSan): 53/53
- cppcheck clean on \`pin_rate_limit.c\`
- \`pio run -e release\`: OK
- \`pio run -e debug\`: OK

## Plan 16 status after merge

- ✅ AuthMode OFF/REQUIRED setting
- ✅ require_auth middleware across 17+ endpoints
- ✅ Origin header / CSRF check
- ✅ 30-min session timeout (LCDPasswordOkSince)
- ✅ **PIN rate limit** (this PR)
- Deferred (Phase 3): per-client session tokens, IPv6-aware rate limiting

## On-device verification (after flash)

- [x] Set LCDPin + AuthMode=1; verify Web UI prompts for PIN.
- [x] Enter wrong PIN 3× fast; 4th attempt returns 429 with Retry-After header.
- [x] Wait through the cooldown; next attempt allowed.
- [x] Enter correct PIN; counter clears (subsequent wrong attempts start fresh).

Closes task #41 and the Phase 2 scope of task #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)