### PR TITLE
docs: segmented audience guides + symptom-indexed troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,138 +1,114 @@
 SmartEVSE v3
 =========
 
-Smart Electric Vehicle Charge Controller
+Smart Electric Vehicle Charge Controller — open-source firmware for a
+DIN-rail AC charger.
 
 <img src="/pictures/SmartEVSEv3.png" alt="SmartEVSE v3 hardware" width="500">
 
 <img src="/pictures/SmartEVSEv3-WebUI.jpg" alt="SmartEVSE v3 Web UI" width="500">
 
-# About this fork
+# What it is
 
-This repository is a fork of [dingo35/SmartEVSE-3.5](https://github.com/dingo35/SmartEVSE-3.5)
-maintained as a testbed for **IT/OT software engineering with AI-assisted development**
-(multi-agent software engineering using [Claude Code](https://claude.ai/claude-code)).
+An EVSE (Electric Vehicle Supply Equipment) — the controller between
+your house wiring and an electric vehicle. It supports:
 
-The upstream SmartEVSE firmware is a monolithic embedded C++/Arduino codebase where the
-state machine, load balancing, MQTT, HTTP, and hardware control all live in a single
-~3,000-line `main.cpp`. This fork restructures the architecture to enable **native host
-testing** of the core logic — pure C modules, context structs, a bridge layer, and HAL
-callbacks — resulting in 1,200+ automated tests (1,096 native C tests across 50 suites,
-50 OCPP protocol tests, and 146 Modbus compatibility tests).
+- 1-phase and 3-phase AC charging, 6–32 A.
+- Fixed charging cable or Type 2 socket.
+- 5 locking actuator types.
+- Direct drive of a mains contactor.
+- Up to 8 modules sharing one mains supply (load balancing).
+- RFID authorization (100 cards).
+- 18 supported Modbus kWh meters + Sensorbox + HomeWizard P1 + REST API.
+- MQTT + Home Assistant auto-discovery.
+- REST API for scripts and dashboards.
+- OCPP 1.6j for public / billed charging.
+- Offline-first Web UI, dark mode, live WebSocket updates.
+- LCD + button configuration on the device itself.
 
-See [Quality Engineering](docs/quality.md) for the full architecture, testing
-methodology, CI/CD pipeline, and hardening approach. See
-[Upstream Differences](docs/upstream-differences.md) for a complete list of changes
-compared to the upstream repository.
+Operating voltage 110–240 VAC. DIN-mount, 3 modules wide (52 × 91 × 58 mm).
 
-# What is it?
+# Pick your path
 
-An open source EVSE (Electric Vehicle Supply Equipment). It supports 1-3 phase
-charging, fixed charging cable or charging socket, locking actuator support (5 types),
-and it can directly drive a mains contactor for supplying power to the EV. It features
-a display for parameter configuration. Up to 8 modules can be connected together to
-charge up to eight EVs from one mains connection without overloading it.
+| You are | Start here |
+|---|---|
+| Installing the hardware (you have the PCB in hand) | [**Installer guide**](docs/guide-installer.md) |
+| Using an already-installed charger | [**Owner guide**](docs/guide-owner.md) |
+| Integrating with Home Assistant / MQTT / REST / OCPP | [**Integrator guide**](docs/guide-integrator.md) |
+| Something is wrong | [**Troubleshooting**](docs/troubleshooting.md) |
+| Adding a feature, fixing a bug, submitting a PR | [**Contributor guide**](docs/guide-contributor.md) |
+| Wondering about LAN security / firmware signing / auth | [**Security**](docs/security.md) |
 
-# Key Features
+# Community
 
-| Feature | Highlights |
-|---------|-----------|
-| **Charging** | 1-3 phase, auto cable detection (13/16/32A), dual contactor outputs, thermal protection |
-| **Solar & Smart Mode** | Solar surplus charging, auto 1P/3P switching, EMA smoothing, dead band regulation |
-| **Load Balancing** | Up to 8 nodes, priority scheduling, oscillation dampening, convergence testing |
-| **OCPP & Authorization** | OCPP 1.6j, RFID (100 cards), pure C logic extraction (85 tests), 50 protocol tests, FreeVend solar safety |
-| **MQTT & Home Assistant** | Change-only publishing (70-97% reduction), fixed HA discovery, per-phase power/energy |
-| **Metering** | 18 Modbus meter types, 146 compatibility tests, HomeWizard P1, Sensorbox, API/MQTT feed, staleness detection |
-| **EVCC Integration** | IEC 61851 state mapping, HTTP phase switching, ready-to-use template |
-| **Diagnostics** | Ring buffer events, LittleFS persistence, WebSocket live stream, test replay |
-| **ERE Session Logging** | Dutch ERE certificate output, MQTT publish, REST endpoint, zero flash wear |
-| **Capacity Tariff** | 15-min peak tracking, monthly peak persistence, automatic current limiting, LCD/Web/MQTT/REST config |
-| **CircuitMeter** | Subpanel metering, breaker protection, ERE circuit verification, all 19 meter types supported |
-| **SoC Injection** | MQTT topics for InitialSoC/FullSoC/EnergyCapacity/EnergyRequest/EVCCID, WiCAN OBD-II integration |
-| **Web UI** | Offline-first, WebSocket updates, dark mode, load balancing dashboard, diagnostic viewer |
-| **Privacy** | No cloud, no tracking, open source |
+- **Dutch-language forum:** [Tweakers GoT — *Zelfbouw Laadpaal ervaringen*](https://gathering.tweakers.net/forum/list_messages/1648387).
+  The canonical community thread with a decade of accumulated buying,
+  installation, and integration experience. Maintainers and experienced
+  users read and answer there.
+- **Issues:** [GitHub Issues](https://github.com/basmeerman/SmartEVSE-3.5/issues).
+- **Releases:** [Releases page](https://github.com/basmeerman/SmartEVSE-3.5/releases).
 
-For detailed feature descriptions and fork improvements, see [Features](docs/features.md).
+# Privacy and longevity
+
+- Works fully offline. No cloud account required.
+- Does not collect or transmit usage statistics.
+- Open-source firmware. Fork it, modify it, keep it running long after
+  commercial chargers go EOL.
+
+# Reference documentation
+
+For topic-organised reference material (the deep detail behind the
+audience guides):
+
+| Area | Document |
+|---|---|
+| Hardware installation | [installation.md](docs/installation.md) |
+| Power-input methods (Sensorbox / P1 / Modbus / API) | [power-input-methods.md](docs/power-input-methods.md) |
+| LCD menu configuration reference | [configuration.md](docs/configuration.md) |
+| Settings matrix with access channels | [configuration-matrix.md](docs/configuration-matrix.md) |
+| Operation guide | [operation.md](docs/operation.md) |
+| MQTT topics + HA discovery | [mqtt-home-assistant.md](docs/mqtt-home-assistant.md) |
+| REST API reference | [REST_API.md](docs/REST_API.md) |
+| OCPP 1.6j coverage | [ocpp.md](docs/ocpp.md) |
+| Solar / Smart mode tuning | [solar-smart-stability.md](docs/solar-smart-stability.md) |
+| Load balancing behaviour | [load-balancing-stability.md](docs/load-balancing-stability.md) |
+| Priority scheduling (multi-node) | [priority-scheduling.md](docs/priority-scheduling.md) |
+| EVCC integration | [evcc-integration.md](docs/evcc-integration.md) |
+| ERE session logging | [ere-session-logging.md](docs/ere-session-logging.md) |
+| Building and flashing firmware | [building_flashing.md](docs/building_flashing.md) |
+| Feature catalogue | [features.md](docs/features.md) |
+| Quality engineering + CI/CD | [quality.md](docs/quality.md) |
+
+# About this repository
+
+This repository is maintained independently. It diverges from the
+reference codebase primarily in two areas: (1) a restructured
+architecture that enables native host testing of the core logic
+(1,200+ automated tests across 50 suites — state machine, parsers,
+validators, OCPP, Modbus), and (2) security hardening of the Web UI and
+firmware update paths (signed firmware, per-endpoint auth gate, PIN
+rate limiter, CSRF/Origin check, secret redaction).
+
+The refactor used multi-agent AI-assisted development (Claude Code) as
+a real-world test of the methodology on safety-critical embedded
+firmware. That's how the test suite and the security work landed so
+quickly. Details in [quality.md](docs/quality.md) for those interested;
+it doesn't affect how you install, use, or contribute.
+
+See [upstream-differences.md](docs/upstream-differences.md) for the
+complete diff against the reference codebase.
 
 # Getting started
 
 ## Connecting to WiFi
 
-Follow the instructions on the [Configuration page](docs/configuration.md#wifi),
-WiFi section.
+See [configuration.md, WiFi section](docs/configuration.md#wifi).
 
 ## Updating firmware
 
-Connect to your WiFi network, then browse to `http://smartevse-xxxx.local/update`
-(replace `xxxx` with your serial number, shown on the display). Select the
-`firmware.bin` and press Update.
+Connect to WiFi, then browse to
+`http://smartevse-<serial>.local/update` (serial shown on the LCD).
+Select `firmware.signed.bin` from the releases page and upload.
 
-# Documentation
-
-## User Documentation
-
-| Document | Description |
-|----------|-------------|
-| [Hardware installation](docs/installation.md) | Wiring, mounting, contactor setup |
-| [Power Input Methods](docs/power-input-methods.md) | Metering options — reliability ranking, setup, troubleshooting |
-| [Configuration](docs/configuration.md) | LCD menu settings reference |
-| [Settings Reference](docs/configuration-matrix.md) | All settings by access channel with safety flags |
-| [Operation](docs/operation.md) | Day-to-day usage guide |
-
-## Feature Documentation
-
-| Document | Description |
-|----------|-------------|
-| [Features & USPs](docs/features.md) | All features with fork improvements |
-| [Upstream Differences](docs/upstream-differences.md) | Complete diff with upstream repo |
-| [Solar & Smart Mode Stability](docs/solar-smart-stability.md) | EMA smoothing, dead bands, phase switch timers |
-| [Load Balancing Stability](docs/load-balancing-stability.md) | Oscillation dampening, diagnostics |
-| [MQTT & Home Assistant](docs/mqtt-home-assistant.md) | Topic reference, HA auto-discovery |
-| [EVCC Integration](docs/evcc-integration.md) | EVCC charger template, phase switching API |
-| [REST API reference](docs/REST_API.md) | HTTP endpoints for external integration |
-| [ERE Session Logging](docs/ere-session-logging.md) | Dutch ERE certificates, HA automation |
-| [OCPP setup](docs/ocpp.md) | Provider guides (Tap Electric, Tibber, SteVe) |
-| [Priority scheduling](docs/priority-scheduling.md) | Load balancing priority configuration |
-
-## Developer Documentation
-
-| Document | Description |
-|----------|-------------|
-| [Quality Engineering](docs/quality.md) | Architecture, testing, CI/CD, hardening, interoperability |
-| [Building & Flashing](docs/building_flashing.md) | Compiling firmware from source |
-| [Coding standards](CODING_STANDARDS.md) | Code conventions for contributors |
-| [Contributing](CONTRIBUTING.md) | How to contribute to this project |
-| [AI agent instructions](CLAUDE.md) | Multi-agent workflow for Claude Code |
-
-# Roadmap
-
-Completed improvement plans, tracked via
-[GitHub Projects](https://github.com/basmeerman?tab=projects):
-
-| Status | Project | PRs | Upstream issues |
-|--------|---------|-----|----------------|
-| Done | Plan 01: Solar & Smart Mode Stability | [#65](https://github.com/basmeerman/SmartEVSE-3.5/pull/65), [#83](https://github.com/basmeerman/SmartEVSE-3.5/pull/83) | [#327](https://github.com/dingo35/SmartEVSE-3.5/issues/327), [#335](https://github.com/dingo35/SmartEVSE-3.5/issues/335), [#316](https://github.com/dingo35/SmartEVSE-3.5/issues/316) |
-| Done | Plan 02: Multi-Node Load Balancing | [#69](https://github.com/basmeerman/SmartEVSE-3.5/pull/69) | [#316](https://github.com/dingo35/SmartEVSE-3.5/issues/316) |
-| Done | Plan 03: OCPP Robustness | [#77](https://github.com/basmeerman/SmartEVSE-3.5/pull/77), [#79](https://github.com/basmeerman/SmartEVSE-3.5/pull/79), [#80](https://github.com/basmeerman/SmartEVSE-3.5/pull/80) | — |
-| Done | Plan 04: EVCC Integration | [#70](https://github.com/basmeerman/SmartEVSE-3.5/pull/70) | [EVCC #13852](https://github.com/evcc-io/evcc/pull/13852) |
-| Done | Plan 05: Meter Compatibility & Modbus | [#76](https://github.com/basmeerman/SmartEVSE-3.5/pull/76) | — |
-| Done | Plan 06: Diagnostic Telemetry | [#84](https://github.com/basmeerman/SmartEVSE-3.5/pull/84) | — |
-| Done | Plan 07: Web UI Modernization | [#85](https://github.com/basmeerman/SmartEVSE-3.5/pull/85) | — |
-| Done | Plan 08: HA MQTT Integration | [#64](https://github.com/basmeerman/SmartEVSE-3.5/pull/64), [#68](https://github.com/basmeerman/SmartEVSE-3.5/pull/68), [#82](https://github.com/basmeerman/SmartEVSE-3.5/pull/82) | [#320](https://github.com/dingo35/SmartEVSE-3.5/issues/320), [#294](https://github.com/dingo35/SmartEVSE-3.5/issues/294), [PR #338](https://github.com/dingo35/SmartEVSE-3.5/pull/338) |
-| Done | Plan 09: Power Input Methods | [#86](https://github.com/basmeerman/SmartEVSE-3.5/pull/86) | — |
-| Done | Plan 10: ERE Session Logging | [#89](https://github.com/basmeerman/SmartEVSE-3.5/pull/89) | — |
-| Done | Plan 11: OCPP Compatibility Testing | [#96](https://github.com/basmeerman/SmartEVSE-3.5/pull/96) | — |
-| Done | Plan 12: Modbus Compatibility Testing | [#97](https://github.com/basmeerman/SmartEVSE-3.5/pull/97) | — |
-| Done | Plan 13: Capacity Tariff Peak Tracking | [#116](https://github.com/basmeerman/SmartEVSE-3.5/pull/116) | — |
-| Done | Plan 14: CircuitMeter — Subpanel Metering | [#117](https://github.com/basmeerman/SmartEVSE-3.5/pull/117) | — |
-| Done | Plan 15: SoC Injection via MQTT | [#115](https://github.com/basmeerman/SmartEVSE-3.5/pull/115), [#116](https://github.com/basmeerman/SmartEVSE-3.5/pull/116) | — |
-
-All 15 improvement plans are complete. The CI/CD pipeline runs a 10-job quality
-gate on every PR, including OCPP interoperability tests (mock CSMS via
-[mobilityhouse/ocpp](https://github.com/mobilityhouse/ocpp)) and Modbus
-compatibility tests (C decode functions called from Python via ctypes). See
-[Quality Engineering](docs/quality.md) for details.
-
-# SmartEVSE App
-
-The SmartEVSE-app can be found [here](https://github.com/SmartEVSE/SmartEVSE-app) or on Google Play
+For the full install flow from boxed PCB to commissioned charger, see
+the [installer guide](docs/guide-installer.md).

--- a/docs/documentation-audience-analysis.md
+++ b/docs/documentation-audience-analysis.md
@@ -1,0 +1,354 @@
+# Documentation audience analysis and restructure proposal
+
+**Date:** 2026-04-15
+**Status:** Decisions locked — execution starts with `guide-installer.md`
+
+## Decisions (locked 2026-04-15)
+
+| # | Question | Decision |
+|---|---|---|
+| Q1 | Segment sizing | B (owner) is largest real-world audience. A2 (installer) docs must be markedly better than upstream. Execution order: installer → owner → integrator → contributor → cross-cutting troubleshooting |
+| Q2 | Fork identity | (b) production-hardened drop-in SmartEVSE, neutral/factual tone, AI-methodology mentioned in footer only |
+| Q3 | Upstream portability | (a) fork-only, no upstream portability tax. Writing style: like a maintainer typing fast, not like polished AI |
+| Q4 | Dutch translation | (a) English only + prominent Tweakers link in README footer. Dutch electrical terms as parentheticals. |
+| Q5 | Car compatibility page | (b) skeleton + community-maintained with staleness guardrails |
+
+**Writing-style guardrails** (applies to every new doc):
+
+- No bullet lists of 5+ items without reason.
+- No meta-paragraphs ("Bottom line:", "In summary:").
+- Short declarative sentences.
+- Tables > prose for reference material.
+- Code examples > conceptual explanations.
+- No em-dashes splitting 3+ clauses.
+- Fork-specific features referenced freely where they add value; no caveats
+  for upstream users.
+
+
+**Sources consulted:**
+
+- `docs/` current contents (27 markdown files + 3 security docs)
+- Root `README.md` (fork) and upstream `dingo35/SmartEVSE-3.5` README
+- Fork issue tracker (basmeerman/SmartEVSE-3.5) — 40 most recent
+- Upstream issue tracker (dingo35/SmartEVSE-3.5) — 60 most recent
+- Tweakers.net GoT forum thread *"Zelfbouw Laadpaal ervaringen"* — the canonical
+  Dutch community thread (2017–2025, 92+ pages, ~1M views). Fetched via the
+  Wayback Machine snapshot (the site requires consent-gate JS).
+
+---
+
+## 1. User segments observed
+
+Six distinct segments show up repeatedly across the three sources. They overlap
+but have very different first-five-minutes needs. Percentages are rough
+eyeball estimates based on post/issue volume, not scientific.
+
+### Segment A — The DIY hardware builder (~30%)
+
+Dominant voice on Tweakers. Buys the PCB kit (or components), solders it,
+designs the meter-cabinet layout themselves, runs the CP/PE cable, picks a
+contactor, selects an RCD (type A vs B debate), picks cable (SFTP CAT6/7 for
+EMC). Often cross-posts with photos of their Dutch/Belgian `meterkast`.
+
+**What they land on the repo looking for:**
+
+- A build-of-materials list (PCB, contactor, RCBO, fixed or socket, cable type).
+- Hardware installation with wiring diagrams for 1-phase and 3-phase.
+- Which meter to buy and how to wire it (Sensorbox vs direct Modbus vs P1).
+- How to flash the firmware the first time (USB-C).
+- How to commission: set mode, set MaxMains, verify CP signal on scope.
+
+**What they do NOT want on the landing page:**
+Architectural notes, pure-C test philosophy, Claude Code framing.
+
+**Dutch-specific concerns:**
+DSMR4 vs DSMR5 timing. P1 poort wiring. Salderingsregeling phase-out.
+Capacity tariff (Belgian + rolling out NL). 3×25 A standard connection.
+
+### Segment B — The installed-kit owner (~25%)
+
+Has the device mounted and powered. Car plugs in and charges in Normal mode.
+Now wants to move to Smart or Solar mode, or hook up Home Assistant, or fix
+the one thing that's weird about their specific EV.
+
+**Landing needs:**
+
+- Day-to-day operation: modes, RFID usage, LCD menu, web dashboard.
+- Mode tuning: Solar thresholds, 1P/3P switching, ImportCurrent.
+- "My car won't start charging" symptom-based troubleshooting.
+- Car-compatibility notes (Zoe 2019, MG4, eGolf, Ioniq, Tesla, etc.).
+
+**Complaint pattern in issues:**
+"After I changed X, Y no longer works." Usually a configuration issue, not a
+bug — but the docs don't guide them back to the answer.
+
+### Segment C — The Home Assistant integrator (~20%)
+
+Forum posts like "ik gebruik ser2net om P1 naar HA te sturen en MQTT
+terug naar SmartEVSE" (from 2025-12). Often has Tibber / EnergyZero /
+ANWB dynamic pricing, wants the charger to react.
+
+**Landing needs:**
+
+- MQTT topic reference (publish + subscribe).
+- HA auto-discovery entity list.
+- REST API (`/settings`, `/currents`, `/mode`) — what to POST, when.
+- `EM_API` flow: how to feed mains measurements from HA into the charger.
+- Rate/timing expectations (the forum shows confusion: "every 1 s required?"
+  — answer is "2–10 s").
+
+**Recurring pain:**
+Timeout handling, DSMR4 5–10 s telegram cadence vs charger's 10 s API
+timeout, HA poll interval defaulting to 60 s. Entity naming / discovery IDs.
+OCPP vs internal load balancing conflict.
+
+### Segment D — The multi-charger / load-balancing operator (~10%)
+
+Households with two EVs, small businesses, apartment buildings. One mains
+connection, two or more SmartEVSE modules, RFID access. Often adds an OCPP
+backend (Tibber, E-Flux, Tap Electric) for billing.
+
+**Landing needs:**
+
+- Master/slave wiring + `LoadBl` setting explained without Modbus jargon.
+- When `LoadBl=0` (standalone) vs `LoadBl=1` (master) vs `LoadBl≥2` (slave).
+- Priority scheduling. Rotation interval. Idle timeout.
+- OCPP provider quickstart (one page per provider would be ideal).
+- Subpanel metering (CircuitMeter, MaxCircuit) for shared branch circuits.
+
+**Upstream issues seen:**
+`#317` master+slave connection error after update; `#316` oscillation in
+smartmode with a few chargers; `#303` incorrect "Smart 1P" during 3-phase;
+`#312` modbus 1P/3P control.
+
+### Segment E — The troubleshooter (across all segments)
+
+Not a distinct persona but a *mode* every other user drops into. The device
+is misbehaving. They need a decision tree, not a reference manual.
+
+**Landing needs:**
+
+- "Car won't start charging" — diode check, PP resistance, CP PWM, diode fail
+  flag, state machine trace.
+- "Solar mode oscillates" — dead band, EMA smoothing, SolarStopTimer.
+- "No MQTT discovery" — broker status, topic prefix, HA config.
+- "Wrong amps reported" — meter selection, CT orientation, phase alignment.
+- "Firmware won't upload" — signed vs unsigned, LCD PIN gate, 411 Content-Length.
+- The telnet debug log as a first-class diagnostic surface.
+
+### Segment F — The contributor / forker (~10%, mostly fork-side)
+
+This fork's primary audience historically. Upstream contributors are a
+smaller slice (dingo35 maintainer + a handful of PR authors).
+
+**Landing needs:**
+
+- Architecture: pure C modules, bridge, state machine, glue layers.
+- Testing: native tests, sanitizers, cppcheck, SbE workflow.
+- CONTRIBUTING: branch style, commit style, PR review, quality gate.
+- CLAUDE.md for AI-agent contributors (already exists).
+- Upstream sync process — how to pull from dingo35 safely.
+
+### Segment-adjacent — Specialist roles
+
+**Security-conscious operator.** Emerging from recent work: AuthMode,
+rate-limit, signed firmware, Origin/CSRF check. Separate page worth writing.
+
+**EVCC user.** Small, growing. Single-page integration guide already exists
+(`docs/evcc-integration.md`) — keep it.
+
+---
+
+## 2. What's wrong with the current entry point
+
+### The fork `README.md` buries the lede
+
+The opening section is about the fork being a *"testbed for IT/OT software
+engineering with AI-assisted development"* with a 1,200-test count. That is
+correct and load-bearing for contributors (Segment F), but it is the **third**
+thing a DIY builder or installer owner wants to read, not the first. Segments
+A/B/C/D bounce on this framing.
+
+The Features table is a kitchen-sink matrix: Charging, Solar, Load Balancing,
+OCPP, MQTT, Metering, EVCC, Diagnostics, ERE Logging, Capacity Tariff,
+CircuitMeter, SoC Injection, Web UI, Privacy — 14 rows. Everything the fork
+can do, none of it ordered by what anyone specifically needs first.
+
+"Getting started" == "connect WiFi + flash firmware". A DIY builder has
+not soldered the PCB yet.
+
+### The `docs/` folder is organized by topic, not by audience
+
+Current files:
+`building_flashing.md`, `configuration-matrix.md`, `configuration.md`,
+`ere-session-logging.md`, `evcc-integration.md`, `features.md`,
+`installation.md`, `load-balancing-stability.md`, `manual-test-plan.md`,
+`mqtt-home-assistant.md`, `ocpp.md`, `operation.md`, `power-input-methods.md`,
+`priority-scheduling.md`, `quality.md`, `REST_API.md`, `solar-smart-stability.md`,
+`upstream-differences.md`, plus `security/` and `upstream-sync/` subdirs.
+
+This is a *complete* reference but has no on-ramp. A new Tweakers reader
+lands on the README, clicks "Configuration", and gets a 500-line LCD menu
+reference before learning whether to pick Normal / Smart / Solar mode for
+their situation.
+
+### No troubleshooting index
+
+Issues #335 (Zoe solar), #346 (MG4), #306 (smart oscillation), #303 (phase
+label wrong), #301 (MG4 3-phase on startup) — all individual reports with
+individual resolutions. No `docs/troubleshooting.md` that groups them by
+symptom for the next user who hits the same thing.
+
+### The Tweakers thread isn't linked anywhere
+
+That thread has **a million views** since 2017, a decade of accumulated
+community wisdom, and the upstream maintainer answers questions in it. The
+repo doesn't point to it. New users who find the forum but not the repo
+end up with half the picture.
+
+---
+
+## 3. Proposed restructure
+
+Two-layer approach: a **segmented landing page** that routes users to the
+right next click, and a **by-audience docs hierarchy** behind it.
+
+### Proposed README.md structure (landing page)
+
+```
+SmartEVSE v3 (basmeerman fork)
+
+<hero image + one-paragraph product description, no architecture talk>
+
+Pick your path:
+  - I want to BUILD one   → docs/guide-builder.md
+  - I OWN one and want to use it → docs/guide-owner.md
+  - I'm integrating it with Home Assistant / OCPP → docs/guide-integrator.md
+  - Something is WRONG → docs/troubleshooting.md
+  - I want to CONTRIBUTE → docs/guide-contributor.md
+
+Community:
+  - Dutch forum: Tweakers GoT "Zelfbouw Laadpaal ervaringen"
+  - Upstream: dingo35/SmartEVSE-3.5
+  - Issues on this fork: ...
+
+About this fork: (1-paragraph, honest — derived work, security hardening,
+testable architecture, 1200+ tests. Link to docs/quality.md and
+docs/upstream-differences.md for details.)
+
+Quick facts: 1-3φ, up to 8 nodes, MQTT+REST+OCPP 1.6j, DIN 3-module,
+110–240 VAC. (What the upstream README opens with — claim the spec.)
+```
+
+Total ≤ 100 lines. The current 138-line README isn't far off in length
+but is 70% mis-targeted at contributors.
+
+### Proposed `docs/` audience-guide pages (new)
+
+Five new landing pages, each ≤ 200 lines, each linking into the existing
+topic-organized docs:
+
+| New file | Audience | Covers |
+|---|---|---|
+| `docs/guide-builder.md` | Segment A | BOM, wiring, contactor selection, meter choice, first-flash, commissioning, Sensorbox vs Modbus vs P1 |
+| `docs/guide-owner.md` | Segment B | Modes explained, LCD menu tour, web UI tour, RFID usage, day-to-day |
+| `docs/guide-integrator.md` | Segment C+D | MQTT topics, HA discovery, REST endpoints, EM_API flow, OCPP providers, multi-charger setup |
+| `docs/guide-contributor.md` | Segment F | Architecture, build, test workflow, SbE, CLAUDE.md link, branch/PR style |
+| `docs/troubleshooting.md` | All | Symptom-indexed: "car won't start charging", "solar oscillates", "MQTT offline", "firmware won't upload", "PIN auth blocks me", with per-symptom triage steps and links to the underlying topic doc |
+
+The existing topic docs (`configuration.md`, `ocpp.md`, `mqtt-home-assistant.md`,
+etc.) stay as deep-reference. The new guides do the curation.
+
+### Minor additions
+
+- **`docs/security.md`** — promote the work done this session (AuthMode,
+  signed firmware, LCD-PIN rate limit, CSRF check, session timeout) into a
+  single operator-facing page. Currently that knowledge is scattered across
+  `security/plan-16-http-auth-layer.md` (design doc), `security/security-review-summary-2026-04.md`
+  (internal summary), and PRs #146/#151/#152/#153/#155/#156.
+
+- **`docs/car-compatibility.md`** — a table of observed interop notes by
+  EV model (Zoe, MG4, Ioniq, Tesla, eGolf). Currently scattered across
+  issues #335/#346/#335/#315/#301 and forum posts.
+
+- **Tweakers / community link** — prominent in README footer. One sentence
+  acknowledging the forum as the day-to-day support channel for Dutch users.
+
+### What NOT to change
+
+- CLAUDE.md stays. It's for AI agents, and it's load-bearing for the fork's
+  contribution workflow.
+- The topic-organized docs stay. They're the reference material the guides
+  link into. Renaming or moving them would break external links.
+- `docs/upstream-sync/` and `docs/security/` stay as internal process docs.
+
+---
+
+## 4. Audience-to-content mapping (current state)
+
+Read as: *"A [segment] user who lands on the README and wants [X], what do
+they actually click through?"*
+
+| Segment | First need | Current path | Friction |
+|---|---|---|---|
+| A Builder | BOM + wiring | README → Hardware installation | Installation.md is good but README doesn't flag it as the first stop for builders |
+| A Builder | First firmware flash | README → Building and flashing | Flashing.md assumes PlatformIO fluency |
+| B Owner | "which mode should I pick" | README → Operation → Configuration | Has to read two docs to get a clear mode recommendation |
+| B Owner | LCD menu reference | README → Configuration matrix | Configuration-matrix.md is dense; no "here are the 5 settings that matter" shortcut |
+| C Integrator | MQTT topic list | README → MQTT & Home Assistant | docs/mqtt-home-assistant.md is comprehensive — this one works |
+| C Integrator | REST API | README → REST_API.md | Works |
+| C Integrator | "feed mains from HA" | No clear path | `power-input-methods.md` buries EM_API; not cross-linked from MQTT doc |
+| D Multi-charger | Master/slave setup | README → Load balancing → LoadBl variable mentions | The actual "how to wire and configure a slave" topic is split across installation + configuration |
+| D OCPP user | Provider-specific quickstart | README → OCPP | `ocpp.md` is feature-oriented, not provider-oriented |
+| E Troubleshoot | "Zoe won't solar charge" | No docs path; fall back to GitHub issue search | High friction |
+| F Contributor | Build + test | README → Quality Engineering | Works well |
+| F Contributor | Commit + PR style | README → CONTRIBUTING.md | Works |
+
+The gaps (rows marked "friction") are the ones the new guide pages would
+close — not by writing new reference material (most of it exists) but by
+**routing** from audience-named starting points into the right topic docs.
+
+---
+
+## 5. Open questions before I start writing
+
+1. **Confirm segment sizing.** Is Segment A (hardware builder) really the
+   biggest audience you serve? Fork usage telemetry would help, but absent
+   that, your gut as the maintainer is the tie-breaker.
+2. **Fork identity.** The current README leads with "testbed for AI-assisted
+   development". Is that still the primary positioning you want, or should
+   the fork present as "a drop-in compatible, security-hardened, better-tested
+   SmartEVSE" with the AI-engineering angle as a secondary story? The
+   restructure proposal assumes the latter — please confirm.
+3. **Upstream coordination.** Some of this (`guide-builder.md`,
+   `troubleshooting.md`) could be contributed upstream in a way dingo35 would
+   accept. Interested in doing that, or is fork-only fine?
+4. **Dutch-language version.** Tweakers is Dutch. A NL translation of the
+   builder and troubleshooting guides would broaden reach substantially.
+   Scope expansion — flag for later, not blocker.
+5. **Car compatibility page.** Useful but requires curation (a living
+   document). Willing to maintain, or skip and let forum do it?
+
+---
+
+## 6. Suggested execution order
+
+If you want to act on this:
+
+1. **Write the new README.md** (replace the hero section with a segmented
+   landing; move the AI-engineering paragraph lower; keep the specs table).
+2. **Write `docs/troubleshooting.md`** — biggest bang-for-buck, closes the
+   highest-friction gap, reuses content you already have in PR descriptions.
+3. **Write `docs/guide-integrator.md`** — consolidates MQTT/REST/OCPP into
+   one audience path, probably reused most by HA users who make up a lot of
+   the issue volume.
+4. **Write `docs/guide-builder.md`** — hardest one, needs photos and BOMs.
+   Partly you can point at upstream's existing images.
+5. **Write `docs/guide-owner.md`** and `docs/guide-contributor.md` —
+   largely stitching existing docs with a narrative wrapper.
+6. **Add `docs/security.md`** — promote your own recent work to
+   operator-facing visibility.
+7. **Promote the Tweakers link** — one-line footer addition.
+
+Steps 1 + 2 alone would make the docs feel much less labyrinthine. The rest
+is fill-in.

--- a/docs/guide-contributor.md
+++ b/docs/guide-contributor.md
@@ -1,0 +1,313 @@
+# Contributor guide
+
+You want to add a feature, fix a bug, or port a change from another
+branch. This guide is the architectural + workflow on-ramp; the
+reference material lives in
+[CONTRIBUTING.md](../CONTRIBUTING.md),
+[CODING_STANDARDS.md](../CODING_STANDARDS.md),
+[quality.md](quality.md), and [CLAUDE.md](../CLAUDE.md).
+
+---
+
+## 1. Repository layout
+
+```
+SmartEVSE-3/
+  src/                       # Firmware source
+    evse_state_machine.c     # Core charge-state machine — pure C, no platform
+    evse_ctx.h               # State context struct
+    evse_bridge.cpp          # Sync firmware globals <-> context (spinlock)
+    mqtt_parser.c            # Pure-C MQTT command parsing
+    http_api.c               # Pure-C HTTP request validation
+    http_auth.c              # Pure-C auth decision (AuthMode + CSRF + timeout)
+    pin_rate_limit.c         # Pure-C PIN-verify rate limiter
+    ocpp_logic.c             # Pure-C OCPP URL + idTag validation
+    firmware_manager.cpp     # OTA update logic
+    esp32.cpp                # Firmware glue / callbacks / hardware I/O
+    network_common.cpp       # WiFi + MQTT client + HTTP server (Mongoose)
+    ...
+
+  test/native/               # Native host tests (runs with plain gcc)
+    tests/                   # One test_*.c per module
+    include/test_framework.h # Minimal Unity-style framework
+    Makefile                 # Builds each suite independently
+
+  data/                      # Web UI source (app.js, index.html, ...)
+  platformio.ini             # ESP32 / CH32 build environments
+
+docs/                         # Reference + guides (you are here)
+```
+
+### Architectural principles
+
+1. **Pure-C modules for testability.** State machine, parsers,
+   validators compile natively with `gcc` — no Arduino, ESP-IDF, or
+   FreeRTOS headers. Every non-trivial logic change is implemented here
+   and tested natively before the firmware glue ever sees it.
+
+2. **Thin glue layer.** `esp32.cpp` and `network_common.cpp` are
+   dispatchers. They convert Arduino types to C types and call pure
+   modules. Keep them boring.
+
+3. **Snapshot structs.** Pure functions operate on struct snapshots
+   (`evse_ctx_t`, `http_settings_request_t`, `mqtt_command_t`). Never
+   on live globals. The bridge layer does the synchronisation.
+
+4. **Bridge pattern.** `evse_bridge.cpp` syncs globals to/from
+   `evse_ctx_t` inside spinlock-protected critical sections. Never
+   access `evse_ctx_t` fields from outside the bridge without explicit
+   synchronisation.
+
+5. **Platform guards only in glue.** `#ifdef SMARTEVSE_VERSION` (30 for
+   v3, 40 for v4 ESP32-S3) belongs in the bridge and glue layers, never
+   in the state machine or parser modules.
+
+Full writeup: [quality.md](quality.md).
+
+---
+
+## 2. Hard rules
+
+Read before touching code.
+
+| Rule | Why |
+|---|---|
+| **Never modify `evse_state_machine.c` without adding or updating tests.** | This module controls contactors, CP pilot, current limiting. Untested changes here can damage vehicles or trip breakers. |
+| **Never use `sprintf`.** Always `snprintf` with explicit buffer size. | Buffer overrun prevention. |
+| **Always NUL-terminate after `strncpy`.** | `strncpy(dst, src, n)` does not terminate when src fills the buffer. Enforced rule after security finding H-5. |
+| **Never log secrets.** | No MQTT passwords, OCPP auth keys, PINs in `_LOG_A` / `_LOG_I` / `Serial.print`. Short fingerprints (first 4 chars + ellipsis) are acceptable. |
+| **Never allocate heap in ISRs or critical sections.** | No `malloc`, no Arduino `String`, no blocking calls inside `portENTER_CRITICAL` / `portEXIT_CRITICAL`. |
+| **Never bypass safety checks.** | Don't remove or weaken overcurrent, CP diode, or state-machine guards. |
+
+Full list in [CLAUDE.md](../CLAUDE.md) — "Critical Rules" section.
+
+---
+
+## 3. The test-first workflow
+
+Every non-trivial change follows this sequence. Skipping steps is how
+regressions land.
+
+### 1. Write the specification
+
+Given / When / Then, before any code. Captured as a block comment on
+each test function, using requirement IDs from
+[test-specification.md](../SmartEVSE-3/test/native/test-specification.md).
+
+```c
+/*
+ * @feature PIN rate limit
+ * @req REQ-AUTH-021
+ * @scenario Third failure arms a 10-second cooldown
+ * @given Two failures already recorded
+ * @when A third failure is recorded and check is called immediately
+ * @then check returns DENY_COOLDOWN and retry_after ~= 10 s
+ */
+void test_pin_rl_third_failure_10s_cooldown(void) { ... }
+```
+
+### 2. Write the test
+
+In `test/native/tests/test_<module>.c`. Should fail at first.
+
+### 3. Implement
+
+Just enough to make the test pass. Don't add features beyond the test.
+
+### 4. Verify
+
+```bash
+cd SmartEVSE-3/test/native
+make clean test
+```
+
+All suites must pass. Not "the one I changed". All.
+
+### 5. Sanitizers
+
+```bash
+make clean test CFLAGS_EXTRA="-fsanitize=address,undefined -fno-omit-frame-pointer"
+```
+
+Catches buffer overruns, use-after-free, undefined behavior.
+
+### 6. Static analysis
+
+```bash
+cppcheck --enable=warning,style,performance \
+  --error-exitcode=1 --suppress=missingIncludeSystem \
+  --inline-suppr \
+  -I SmartEVSE-3/src -I SmartEVSE-3/test/native/include \
+  SmartEVSE-3/src/evse_state_machine.c \
+  ...                                   # full list in CLAUDE.md
+```
+
+Must be clean.
+
+### 7. Firmware builds
+
+```bash
+pio run -e release -d SmartEVSE-3/      # ESP32 v3
+pio run -e debug   -d SmartEVSE-3/      # ESP32 v3 debug
+pio run -e v4      -d SmartEVSE-3/      # ESP32-S3 v4
+pio run -e ch32    -d SmartEVSE-3/      # CH32 co-processor
+```
+
+All environments must build. Type errors, missing symbols, Arduino API
+misuse — these only surface in the platform builds.
+
+### 8. Push + PR
+
+Branch name `fix/<topic>` or `feat/<topic>`. PR description: problem,
+approach, tests added, verification commands run. Keep PRs focused —
+one change per PR.
+
+---
+
+## 4. Specialist roles
+
+Changes are easier to review when the author has context on the area.
+`CLAUDE.md` enumerates specialist roles with file ownership and domain
+knowledge. Quick map:
+
+| Area | Owns | Req prefix |
+|---|---|---|
+| State machine | `evse_state_machine.c`, `evse_ctx.h`, `evse_bridge.cpp` | REQ-SM-, REQ-ERR- |
+| Load balancing | Multi-node logic in `main.cpp` (extraction candidate) | REQ-LB-, REQ-MULTI-, REQ-PWR- |
+| Solar / smart mode | Mode logic in `main.cpp` + state machine | REQ-SOL-, REQ-PH- |
+| OCPP | `ocpp_logic.c` + OCPP library integration | REQ-OCPP- |
+| Network / MQTT / HTTP | `network_common.cpp`, `mqtt_parser.c`, `http_api.c` | REQ-MQTT-, REQ-API- |
+| Modbus / metering | `modbus.cpp`, meter code | REQ-MTR- |
+| Web UI | `data/` → `packed_fs.c` | REQ-API- |
+| Test infrastructure | `test/native/` | — |
+
+If a PR crosses roles, call out which ones in the description. Reviewers
+pick up faster.
+
+---
+
+## 5. Testing philosophy — SbE
+
+Specification-by-Example. Every test function has a block comment with
+`@feature`, `@req`, `@scenario`, `@given`, `@when`, `@then`. A
+traceability script walks these and produces
+[test-specification.md](../SmartEVSE-3/test/native/test-specification.md)
+plus an HTML matrix. CI enforces 100% requirement coverage.
+
+Regenerate after adding tests:
+
+```bash
+cd SmartEVSE-3/test/native
+python3 scripts/extract_traceability.py \
+  --markdown test-specification.md \
+  --html traceability-report.html
+```
+
+CI runs this automatically on merge. Locally, regenerate before asking
+for review so the matrix is current.
+
+---
+
+## 6. AI-agent contributors
+
+This codebase was refactored using multi-agent AI-assisted development.
+That continues to be a supported contribution mode. If you're running
+Claude Code or similar:
+
+- Read [CLAUDE.md](../CLAUDE.md) in full before starting. It contains
+  the hard rules, file-ownership boundaries, and deviation protocol.
+- Assign a specialist role per agent based on the file scope of the
+  task.
+- The Quality Guardian pattern (one agent reviewing, others
+  implementing) is documented in CLAUDE.md — use it on multi-agent
+  workflows.
+- AI-authored commit messages should include the
+  `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`
+  trailer. Reviewers need to see it clearly labelled.
+
+Human contributors: nothing changes for you. Write code, write tests,
+open PRs. The agent workflow is additive, not mandatory.
+
+---
+
+## 7. Memory budget
+
+| Target | Flash budget | RAM budget | Current |
+|---|---|---|---|
+| ESP32 v3 | 95% (1,680 KB) | 90% (288 KB) | ~86% / ~24% |
+| ESP32 v4 (S3) | 95% | 90% | ~84% |
+| CH32 | 95% (62 KB) | 90% (18 KB) | ~59% / ~19% |
+
+Before merging, verify your PR doesn't push past the budget. The
+release build log prints flash and RAM usage at the end. CI enforces.
+
+For features that would push past budget, consider moving them behind
+a compile-time flag or splitting across builds.
+
+---
+
+## 8. Common contribution patterns
+
+### Fixing a bug reported in a GitHub issue
+
+1. Reproduce locally. If you can't, ask for a telnet log in the issue.
+2. Find the failing scenario. Write a test that exercises it.
+3. The test should fail on `main` and pass with your fix.
+4. Link the issue in the PR description.
+
+### Porting a change from another branch
+
+1. Identify the source commit. `git log` on the source branch.
+2. Read the change. Understand what it does before copying.
+3. Recreate manually. **Do not** cherry-pick without review — the
+   state-machine area has architectural differences that make direct
+   cherry-picks compile but break tests.
+4. Add a short note to `docs/upstream-sync/` describing the port.
+
+### Adding a feature
+
+1. Write a short design note. Publish in `EVSE-team-planning/` or as
+   an issue with the `design` label.
+2. Get agreement on the design before coding.
+3. Implement test-first per §3.
+4. Large features: increment-per-PR. Don't merge giant branches.
+
+### Touching the web UI
+
+Files in `data/` are packed into `packed_fs.c` at build time by the
+pre-script `SmartEVSE-3/packfs.py`. Running `pio run` regenerates it.
+**Commit both the source change and the regenerated `packed_fs.c`** —
+CI checks they're in sync.
+
+### Touching native-test infrastructure
+
+Changes to `test/native/Makefile` or `test_framework.h` affect every
+test. Propose these changes as standalone PRs, not bundled with feature
+work.
+
+---
+
+## 9. What not to do
+
+- **Don't refactor Arduino `String` to `char[]`** in non-safety code.
+  It works. Churn risks payload truncation for no benefit.
+- **Don't add `#include` dependencies** from pure-C modules to
+  Arduino / ESP-IDF headers. The native-test build will break.
+- **Don't add FreeRTOS task creation** without documenting stack size
+  rationale and checking the memory budget.
+- **Don't remove test assertions.** Tests are the safety net.
+- **Don't scope-creep PRs.** If you spotted an unrelated issue while
+  doing a fix, open a separate PR.
+- **Don't commit generated files that aren't required.** `packed_fs.c`
+  is required (CI checks). Traceability artefacts are auto-generated by
+  CI, don't commit them locally.
+
+---
+
+## 10. Where next
+
+- [CLAUDE.md](../CLAUDE.md) — full agent / human contribution rules.
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — submission process, branch style, PR review.
+- [CODING_STANDARDS.md](../CODING_STANDARDS.md) — naming, formatting, safety idioms.
+- [quality.md](quality.md) — architecture, test pipeline, CI/CD.
+- [test-specification.md](../SmartEVSE-3/test/native/test-specification.md) — current SbE spec + requirement coverage.

--- a/docs/guide-installer.md
+++ b/docs/guide-installer.md
@@ -1,0 +1,604 @@
+# Installer guide
+
+You have the hardware. This guide takes you from a boxed module to a
+working charger: choosing the contactor and RCD, sizing the branch
+circuit, shielding the CP cable, commissioning without a car connected.
+
+If you have not yet bought hardware, the Dutch
+[Tweakers forum](https://gathering.tweakers.net/forum/list_messages/1648387)
+is the canonical community resource and has years of accumulated buying
+and integration advice. This guide assumes you have the v3 or v3.5 PCB
+in hand.
+
+**Audience:** competent-DIY to electrician. If you have never wired a
+meter cabinet (Dutch: *meterkast*, Flemish: *zekeringkast*) and don't
+know the difference between an MCB and an RCBO, hire an electrician.
+Doing a 32 A branch wrong kills people.
+
+> [!WARNING]
+> All wiring work is done with **full mains power disconnected at the
+> house main switch**. Verify with a non-contact tester. Do not rely
+> on the RCD being tripped — the neutral may still be live.
+
+---
+
+## 1. What you need before you start
+
+### Hardware checklist
+
+| Item | Notes |
+|---|---|
+| Charger module (v3 or v3.5 PCB) | 3-DIN width, 52 × 91 × 58 mm. Check you got the connector block + CP/PP terminals + RGB LED |
+| Contactor | See [§5 Contactor selection](#5-contactor-selection). **Do not** use silent/AC-DC contactors |
+| Residual-current device | See [§4 RCD selection](#4-rcd-selection). Type A with internal DC-leak detection is standard on this PCB |
+| MCB / circuit breaker | Sized to branch cable + connector rating (16 A or 32 A typical) |
+| Meter (one of) | See [§7 Meter selection](#7-meter-selection). Sensorbox, HomeWizard P1, DIN-rail Modbus meter, or API-fed |
+| Branch cable | 2.5 mm² (16 A) or 6 mm² (32 A), H07V-K or XMvK. Length drives the sizing — derate for long runs |
+| Control cable | Cat5 or better for RS485 meter bus. CAT6/7 SFTP if CP runs > 30 m (see [§6](#6-control-wiring-and-cp-cable)) |
+| Connector | Type 2 socket or fixed cable; PP resistor matters — see [§8 Cable and connector](#8-cable-and-connector) |
+| Enclosure (outdoor) | IP54+ if mounted outside; cable glands sized to cable OD |
+
+### Tools
+
+- Multimeter with continuity and AC voltage modes
+- Non-contact voltage tester
+- Torque screwdriver (terminal torque matters for 32 A connections — manufacturer spec is usually 1.2–2.0 Nm)
+- Crimping tool for ferrules if using stranded cable into cage-clamp terminals
+- Oscilloscope *optional but useful* for CP signal verification at commissioning
+
+### What you do NOT need
+
+- PlatformIO or any dev environment. You can install and commission the
+  hardware without touching code. Firmware updates happen via the web UI.
+- A car. The first-boot checks in §10 run without an EV connected.
+
+---
+
+## 2. Safety — non-negotiables
+
+Short list. If any of this is news, stop and hire an electrician.
+
+1. **De-energize before wiring.** Main switch off, verify with a tester,
+   tag it off. Both line and neutral.
+2. **PE continuity** from the SmartEVSE chassis screw all the way back to
+   the installation earth rod. Test with a low-ohm meter (< 0.5 Ω is a
+   reasonable target for a domestic setup).
+3. **RCD test.** After power-up, press the test button on every RCD in
+   the meter cabinet. If any fails to trip, fix before connecting a car.
+4. **Torque.** Under-torqued 32 A terminals overheat and melt. Use a
+   torque screwdriver and check every terminal.
+5. **Phase rotation.** For 3-phase installs, verify L1/L2/L3 rotation
+   matches existing house wiring. Wrong rotation can damage the
+   connected EV or confuse the meter's phase mapping.
+
+---
+
+## 3. Meter cabinet planning
+
+### Dutch 3×25 A typical layout
+
+The common domestic Dutch supply (NL *aansluiting*) is **3×25 A**, shared
+with the house consumer unit. Belgian domestic is often **3×40 A**. Your
+SmartEVSE + car is a meaningful fraction of that budget. A 32 A charger
+on a 3×25 A supply will trip the house main within seconds in worst-case
+load — this is exactly what load balancing is for.
+
+```
+                 Grid
+                  │
+      ┌────────── Kasko / hoofdschakelaar (house main switch) ─────────┐
+      │                                                                 │
+  [Hoofdzekering 3×25A / 3×35A / 3×40A]                                  │
+      │                                                                 │
+  [Electricity meter (P1 port for DSMR smart meter)]                    │
+      │                                                                 │
+  ┌───┴────────────┐                                                    │
+  │ Hoofdschakelaar│                                                    │
+  │  (main switch) │                                                    │
+  └───┬────────────┘                                                    │
+      │                                                                 │
+      ├──── Existing house groups (via existing ALS/RCBO)                │
+      │                                                                 │
+      └──── NEW: SmartEVSE branch ──── RCBO/MCB ──── Contactor ─── Socket/Cable
+```
+
+### Space budget
+
+| Component | DIN modules | Notes |
+|---|---|---|
+| SmartEVSE PCB | 3 | Fits standard DIN |
+| Contactor 4-pole, 40 A | 3–4 | IKA432-40 is 3 modules |
+| 3-pole MCB / RCBO | 3 | Sized to branch |
+| Meter (if DIN Modbus) | 3–4 | Eastron SDM630 is 4 modules |
+| Wiring space | +20% | Terminal access, dressing |
+
+Budget **at least 9–10 DIN modules of free space** for a fresh install.
+If the existing meter cabinet is full, you need an extension box
+(*onderkast* / *aanbouwkast*).
+
+### Electronics next to socket, or in the meter cabinet?
+
+Both work. The Tweakers thread leans toward **electronics in the meter
+cabinet**, power cable out to a socket on the wall. The alternative —
+SmartEVSE PCB in a pole or wall housing at the charge point — requires a
+bigger outdoor enclosure and more weather sealing.
+
+The control cable (RS485 + CP) between meter cabinet and charge point is
+the length-critical bit. Up to ~30 m is forgiving; longer than that,
+shield the CP cable. See §6.
+
+---
+
+## 4. RCD selection
+
+The forum argues about this more than anything else. The short version:
+
+> [!NOTE]
+> The SmartEVSE v3 PCB has **built-in 6 mA DC-leakage detection
+> (EN 62955)**. This is what elevates a Type A RCD to meeting the
+> Mode-3 charger DC-fault requirement. You do NOT need an external
+> Type B RCD on this hardware — a Type A **on top of** the PCB's DC
+> detection is the standard, approved-by-norm combination.
+
+### The options
+
+| RCD class | Trips on | Needed on SmartEVSE v3? | Cost |
+|---|---|---|---|
+| Type AC | AC faults only | **Never** — not compliant for EV charging | Cheap |
+| Type A | AC faults + pulsing DC (< 6 mA DC blinding threshold) | **Yes** — this is what you buy | €15–40 |
+| Type B | AC + smooth DC up to 10 mA | **Not required** because PCB does DC detect | €100–250 |
+| Type B+ (Doepke EV / KNX variants) | B-rated with MID metering | Overkill for home install | €300+ |
+
+### Combined RCBO or separate RCD + MCB
+
+Two ways to wire the branch:
+
+**Option 1 — one RCBO on the EV branch.** Combined device, 3 modules.
+Example: Hager ADS932D (4-pole, 32 A, 30 mA type A). Cleanest install.
+
+**Option 2 — RCD on the common feed + MCB on each branch.** One Type A
+RCD feeds multiple branches (EV + solar + other), then a plain MCB on
+each branch. Cheaper per-branch if you have 2–3 branches behind one RCD.
+But one faulty device trips them all.
+
+Option 1 is the default recommendation for a single new EV branch. Option 2
+becomes cheaper once you're adding solar inverters on the same RCD.
+
+### Common mistakes
+
+- **Using a Type AC RCD** on the EV branch. Non-compliant. Fails insurance
+  check. Replace with Type A.
+- **Assuming "Type B+ is safer so buy that"**. Type B on SmartEVSE v3 is
+  double-protection that may cause nuisance trips because the PCB's
+  own DC detect can interact with a downstream Type B. Type A is
+  specified for a reason.
+- **Under-sized RCD current rating.** A 25 A RCD fronting a 32 A branch
+  will overheat. RCD rating ≥ branch rating.
+
+---
+
+## 5. Contactor selection
+
+The single biggest gotcha. From the product documentation and a decade
+of forum experience:
+
+> [!WARNING]
+> Do **not** use silent contactors, AC-DC contactors, or energy-efficient
+> contactors (ABB ESB series, Hager ESCxxx**S** with the "silent" S suffix).
+> The SmartEVSE drives the contactor coil with a low-hold / high-pull
+> waveform that does not work on silent contactors — the contactor will
+> chatter, weld, or fail to close.
+
+### Recommended parts
+
+| Part | Rating | Poles | Notes |
+|---|---|---|---|
+| Iskra IKA432-40 | 40 A, AC-1 | 4 (3P + N) | Default recommendation. Widely available. |
+| Hager ESC440 (without "S") | 40 A, AC-1 | 4 | Equivalent to Iskra. Verify it's the non-silent variant |
+| Chint NC1-4025 | 40 A | 4 | Budget option, confirmed working on the forum |
+| Siemens 3RT2026-1BB40 | 25 A, AC-3 | 4 | More expensive but heavier-duty |
+
+### Sizing
+
+**16 A charger installation:** 25 A AC-1 contactor is fine.
+**32 A charger installation:** 40 A AC-1 is the default. Do not undersize —
+contactors derate with ambient temperature and lifetime cycles.
+
+### Pole count
+
+For 3-phase charging use a **4-pole contactor** (3P + N). Switching the
+neutral matters for two reasons:
+
+1. **Safety.** Phase-only switching leaves L1 potentially live on the
+   CCS connector if the neutral is interrupted elsewhere in the
+   installation. Code prohibits this in most jurisdictions.
+2. **Phase switching (EnableC2).** If you want to add a second
+   contactor to switch between 1-phase and 3-phase on the fly (see §9),
+   the first contactor must already be 4-pole so C2 can break L2+L3
+   without exposing dangerous neutral-only conditions.
+
+For fixed 1-phase installs, a 2-pole (L + N) contactor is correct.
+
+---
+
+## 6. Control wiring and CP cable
+
+Three cable runs come out of the SmartEVSE PCB:
+
+1. **RS485 meter bus** — to the mains meter (Sensorbox, Modbus DIN
+   meter). Cat5 or better, one twisted pair for A/B, one pair for GND.
+2. **CP + PP signal** — to the Type 2 socket or the fixed cable. Carries
+   the ~1 kHz PWM pilot signal.
+3. **Contactor coil** — 230 VAC, switched by the PCB.
+
+### CP cable: shielded vs unshielded
+
+The CP signal is a ±12 V PWM at 1 kHz. It is more noise-sensitive than
+people expect. **Unshielded control cable over 20–30 m will cause
+intermittent charge aborts** — the car sees noise on CP, interprets it
+as a cable removal, stops charging mid-session.
+
+| CP run length | Minimum cable |
+|---|---|
+| ≤ 5 m (PCB next to socket) | Any 0.75 mm² flex is fine |
+| 5–30 m | Cat5 is adequate in most houses, twisted pair for CP/PE |
+| > 30 m | **SFTP CAT6/7, shield bonded to PE at ONE end only (the meter cabinet side)** |
+| Outdoor / long run > 50 m | Consider not doing it. Move the PCB closer. |
+
+The Tweakers thread has documented cases of SVV 10×0.8 (common
+telephone wire) causing 3–5 s charge aborts that disappeared the moment
+the cable was replaced with CAT6 SFTP.
+
+### RS485 meter bus
+
+| Parameter | Value |
+|---|---|
+| Baud rate | 9600 |
+| Parity | None |
+| Stop bits | 1 |
+| Address range for meters | **11 or higher** — addresses 1–10 are reserved for SmartEVSE node + Sensorbox |
+| Twisted pair | A/B must share one twisted pair (e.g. green + green/white on Cat5) |
+| GND | Bond the meter GND to the SmartEVSE GND terminal |
+
+Two meters sharing the bus? Different addresses, daisy-chained A to A,
+B to B. No star topology on RS485.
+
+---
+
+## 7. Meter selection
+
+The charger needs to know the **mains current** (to avoid overloading the
+house connection) and *optionally* the **EV current** (for energy
+billing / subpanel protection). Four ways to feed it:
+
+| Method | Hardware | Telegram rate | Reliability | Cost |
+|---|---|---|---|---|
+| **Sensorbox v2** | SmartEVSE companion, 3× CT clamps | ~1 s | High — purpose-built | €60–80 |
+| **HomeWizard P1 meter** | P1 to wifi, reads DSMR smart meter | 1 s (DSMR5) or 10 s (DSMR4) | High on DSMR5, marginal on DSMR4 | €40 |
+| **Modbus DIN meter** | Eastron SDM630 etc., CT or direct | 1–2 s | Highest | €100–180 |
+| **API-fed** (`EM_API`) | Home Assistant / custom script pushes via REST | Anything slower than 10 s = charger timeout | Depends on your HA uptime | Free (if you already run HA) |
+
+### Decision tree
+
+- **Dutch house with DSMR5 smart meter + you already run Home Assistant**
+  → HomeWizard P1 or HA-fed. P1 is simpler, HA-fed is more flexible.
+- **Older DSMR4 meter (10 s telegrams)** → Sensorbox or Modbus. API-fed
+  will timeout-loop the charger.
+- **No smart meter / commercial install / subpanel protection** →
+  Modbus DIN meter direct-inline.
+- **Budget constrained, short run, single-phase** → Sensorbox.
+
+For a comprehensive reference see [power-input-methods.md](power-input-methods.md).
+
+### CT clamp orientation
+
+CT clamps have an **arrow printed on the case** indicating current
+direction. Arrow points **toward the load** (away from the grid). Wrong
+direction = negative current values in the charger = load balancing
+thinks you're exporting when you're consuming, and it will happily add
+32 A on top.
+
+**Verification after first boot:**
+
+1. Turn off any solar inverter.
+2. Watch the Web UI's current readings with one house appliance running
+   (kettle, dryer).
+3. Values should be positive (~8–10 A for a kettle on one phase).
+4. If negative, flip the CT clamp or swap the two secondary wires at
+   the Sensorbox terminals.
+
+### Modbus meter address
+
+The charger reserves Modbus addresses 1–10 for its own use
+(SmartEVSE nodes + Sensorbox). **Meters must be at address 11 or higher**,
+or they will conflict with node communication.
+
+Common cause of "no meter data" after install: meter left at factory
+default address 1. Set it to 11 or 12 on the meter's own menu before
+wiring.
+
+### Inverted wiring (Eastron fed from below)
+
+Dutch meter cabinets wire the supply from the bottom. Eastron 3-phase
+meters assume top-feed, so in a bottom-fed cabinet the current
+direction is reversed. Select **"Inverted Eastron"** meter type in the
+SmartEVSE menu, not plain "Eastron". Confirm the fix by checking that
+current values are positive under load (see CT orientation check above).
+
+---
+
+## 8. Cable and connector
+
+### Fixed cable vs socket
+
+**Fixed cable (Type 2 plug dangling from the wall):**
+
+- User plugs the car in directly.
+- Proximity Pilot resistor is internal; the EVSE knows the cable's
+  rating and doesn't need to negotiate.
+- Slightly simpler install, better for single-user home.
+
+**Type 2 socket (user brings their own cable):**
+
+- Future-proof, cable replaceable.
+- PP resistance detected by the EVSE — a 13 A cable caps charging at
+  13 A even if the socket/branch can do 32 A.
+- Required for commercial/public installs.
+
+### PP resistor values (IEC 62196)
+
+If you're wiring a fixed cable and need to set the PP resistor:
+
+| Current rating | Resistor (PP → PE) |
+|---|---|
+| 13 A | 1.5 kΩ |
+| 20 A | 680 Ω |
+| 32 A | 220 Ω |
+| 63 A | 100 Ω |
+
+Fixed-cable setups without a PP resistor will report "no cable" —
+always install the resistor.
+
+---
+
+## 9. Mounting and enclosure
+
+### DIN rail, indoor
+
+Most installs. Standard 35 mm DIN rail in the meter cabinet. No special
+sealing needed. Good airflow — avoid mounting directly under a hot
+inverter.
+
+### Outdoor / pole
+
+If the SmartEVSE PCB lives outside:
+
+- **IP54 minimum** for the enclosure, IP65 if exposed to driven rain.
+- **Cable glands** sized to cable OD, not the hole size. Wrong-sized
+  glands leak, water gets into the PCB, PCB dies.
+- **UV resistance** on the enclosure if south-facing.
+- **Ventilation.** Sealed enclosures trap heat. Specs say the PCB
+  operates to +50 °C ambient; in summer sun an unventilated black
+  plastic box exceeds that easily.
+
+### Outdoor socket height and protection
+
+Dutch convention: 1.0–1.2 m above ground. Higher in areas with snow
+drifts. Rain cover over the socket. Do not mount directly in the drip
+line of the garage roof.
+
+---
+
+## 10. First boot and commissioning — **without a car connected**
+
+> [!IMPORTANT]
+> Do **not** connect a car until every step here passes. Connecting an
+> EV to a miswired charger can brick the car's onboard charger.
+> Repairs are out-of-warranty and cost €2000+.
+
+### Step 1 — Power on, no car
+
+1. Close the branch MCB / RCBO.
+2. LCD should boot. Version number appears.
+3. Check the LCD for **State: A** (no car connected).
+4. RGB LED should glow white or green (idle, no error).
+
+If the LCD does not boot: check 230 V at the module's mains terminals.
+If it boots and shows an error: note the error code and see
+[troubleshooting.md](troubleshooting.md).
+
+### Step 2 — WiFi and web UI
+
+Follow [configuration.md#wifi](configuration.md) to join your WiFi. Then
+browse to `http://smartevse-<serial>.local/`.
+
+Set an **LCD PIN** immediately. Several security features (web UI auth
+gate, rate-limited PIN verify, debug-firmware upload control) rely on
+having a PIN set. Default PIN = 0 means no auth.
+
+### Step 3 — Meter verification
+
+With the car unplugged and one house appliance running (dryer, kettle):
+
+1. On the web UI, look at **Mains currents** (L1/L2/L3).
+2. Values should be **positive** and roughly match the appliance load.
+3. If you see the kettle on a different phase than expected, your
+   CT-clamp-to-phase mapping is swapped. Fix at the Sensorbox, not in
+   firmware.
+4. If you see negative values, CT clamp is backwards. Flip it.
+
+### Step 4 — CP signal verification (optional, recommended)
+
+With an oscilloscope on the CP pin to PE:
+
+| State | CP waveform | DC level |
+|---|---|---|
+| No car (A) | +12 V flat | +12 V |
+| Car connected, not ready (B) | ±12 V, 10 % duty 1 kHz PWM | ~+9 V mean |
+| Car drawing power (C) | ±12 V, duty matches current setpoint | ~+6 V mean |
+
+If you see a flat DC level with no PWM in state B, the LEDC channel
+isn't driving (firmware issue, not wiring).
+
+### Step 5 — Mode and current limits
+
+On the LCD or web UI, set:
+
+| Setting | Value |
+|---|---|
+| Mode | **Normal** for the first plug-in test. Switch to Smart/Solar later |
+| MaxMains | Your house main rating, minus a margin. On a 3×25 A = set 23 A |
+| MaxCurrent | Charger branch rating. 16 A or 32 A |
+| MaxCircuit | 0 (disabled) unless you're on a subpanel (see §11) |
+| LoadBl | 0 (standalone). Set to 1+ only for multi-charger installs (see §12) |
+
+Save. Reboot if the LCD prompts.
+
+### Step 6 — First car plug-in
+
+1. Plug in your car. State should transition **A → B** within a second.
+2. Press the RFID card (if configured) or accept in Normal mode.
+3. State transitions **B → C**. Contactor should close — audible click.
+4. Measure current on L1 with a clamp meter. Should match the current
+   setpoint on the LCD (e.g. 16 A).
+
+If the contactor clicks in and then out immediately, see §13 gotchas.
+
+If the car never exits state B, the car doesn't see a valid CP PWM. Go
+back to step 4 — CP signal is likely broken.
+
+### Step 7 — RCD test
+
+Press the RCD test button on the EV branch. The charger drops out. LCD
+shows state A. Reset the RCD. Plug the car back in. Charging resumes
+from state A → B → C. If it doesn't resume cleanly, check for welded
+contactor (§13).
+
+---
+
+## 11. Subpanel / "garage" configuration
+
+If the SmartEVSE branch is behind a subpanel (garage, outbuilding) that
+also feeds other loads (workshop tools, lighting), you need
+**MaxCircuit** to protect the subpanel feed.
+
+```
+                             mains
+                               │
+                   [house main breaker 3×25 A]
+                               │
+                        [Mains meter]
+                               │
+              ┌────────────────┴─────────────────┐
+              │                                  │
+   [house groups, 16 A]            [subpanel feed, 16 A]
+                                                 │
+                                          [EV meter]
+                                                 │
+                                     ┌───────────┴──────────┐
+                                     │                      │
+                           [workshop 16 A]       [SmartEVSE 16 A]
+```
+
+**Configuration:**
+
+| Setting | Value |
+|---|---|
+| MaxMains | 23 A (the house main, minus margin) |
+| MaxCircuit | 15 A (the subpanel feed, minus margin for the other workshop loads) |
+| Mode | **Smart** or **Solar** (Normal mode ignores MaxCircuit) |
+
+The charger will clamp its own current so that neither the 23 A mains
+nor the 15 A subpanel is exceeded. You do **not** need Load Balancing
+(LoadBl) for this — that's only for multiple SmartEVSE modules sharing
+one supply.
+
+---
+
+## 12. Multi-charger (master/slave) wiring
+
+Up to 8 SmartEVSE modules on one mains supply. One master, up to 7
+slaves (nodes). They share one meter reading and coordinate current
+allocation.
+
+### Wiring
+
+- A, B, GND from the **master** to **all nodes**. Daisy-chain A→A, B→B,
+  GND→GND. Not a star.
+- Sensorbox (if used) connects to the **same bus** as the master — the
+  +12 V wire goes to **only one** SmartEVSE (the master).
+
+### Configuration
+
+| Role | LoadBl value |
+|---|---|
+| Standalone (only charger) | 0 |
+| Master | 1 |
+| First slave | 2 |
+| Second slave | 3 |
+| … up to 8 modules | up to 8 |
+
+Only the master has MaxMains / MaxCircuit configured. Slaves inherit
+from the master via Modbus broadcast.
+
+### Common wiring mistake
+
+The Tweakers thread's recurring version of this: "I have two
+SmartEVSEs but LoadBl=0 on both, and they both try to pull 32 A." This
+is not load balancing — it's two standalone chargers on the same bus
+fighting over the meter. Set one to LoadBl=1, the other to LoadBl=2.
+
+---
+
+## 13. Common installation gotchas
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Contactor chatters / fails to close | Silent/AC-DC contactor | Replace with AC-1 type (Iskra IKA432-40 etc.) |
+| Currents shown negative in web UI | CT clamp arrow backwards | Flip the clamp around the wire |
+| No meter data / timeout errors | Modbus address conflict (meter at 1–10) | Set meter address to 11+ |
+| No meter data / wrong phase mapping | Eastron fed from below | Select "Inverted Eastron" not "Eastron" |
+| No meter data / wrong poles | A/B swapped | ABB and Carlo Gavazzi have A/B reversed vs. most meters. Swap. |
+| Charging aborts every 3–5 seconds | Unshielded CP cable > 20 m | Replace with SFTP CAT6/7, shield to PE one side |
+| Car state A → B but never C | Car not seeing valid CP PWM | Check CP wiring, verify PWM on scope |
+| Car charges at 16 A when set to 32 A | PP cable limit (13 A or 16 A cable) | Upgrade cable or set MaxCurrent to match |
+| PCB boots but web UI rejects firmware upload | Unsigned firmware requires a verified LCD PIN (debug builds only); release builds always require a signed `.signed.bin` | Either upload a signed build, or set + verify LCD PIN first. See [security.md](security.md) |
+| LCD shows phase error on 3-phase | L1/L2/L3 rotation wrong | Swap two phase wires at the contactor input |
+
+---
+
+## 14. Firmware first-flash
+
+The PCB ships with a firmware on it. It probably isn't the latest. To
+update:
+
+1. Join WiFi (§10 step 2).
+2. Browse to `http://smartevse-<serial>.local/update`.
+3. Upload the latest `firmware.signed.bin` from the
+   [releases page](https://github.com/basmeerman/SmartEVSE-3.5/releases).
+4. Unsigned `firmware.bin` is rejected by default on release builds.
+   For local development iteration see
+   [guide-contributor.md](guide-contributor.md).
+
+Full build + flash instructions in [building_flashing.md](building_flashing.md).
+
+---
+
+## 15. Next steps
+
+Once the charger is installed, powered, and state A → B → C works with
+your car in Normal mode:
+
+- **[guide-owner.md](guide-owner.md)** — day-to-day usage, switching to Smart/Solar mode, LCD menu tour.
+- **[guide-integrator.md](guide-integrator.md)** — MQTT topics, Home Assistant, REST API, OCPP providers.
+- **[configuration.md](configuration.md)** — LCD menu reference.
+- **[power-input-methods.md](power-input-methods.md)** — detailed meter setup.
+- **[mqtt-home-assistant.md](mqtt-home-assistant.md)** — MQTT integration.
+
+If something is wrong, the
+[troubleshooting guide](troubleshooting.md) is the first stop.
+
+For Dutch-language community support, the
+[Tweakers "Zelfbouw Laadpaal ervaringen" thread](https://gathering.tweakers.net/forum/list_messages/1648387)
+is the canonical resource — maintainers and experienced users read and
+answer there.

--- a/docs/guide-integrator.md
+++ b/docs/guide-integrator.md
@@ -1,0 +1,449 @@
+# Integrator guide
+
+You want to connect the charger to Home Assistant, a custom script, an
+OCPP backend, or run multiple chargers on one mains connection. This
+guide routes you through the options and covers the parts where people
+most often trip.
+
+For the reference manuals see
+[mqtt-home-assistant.md](mqtt-home-assistant.md),
+[REST_API.md](REST_API.md),
+[ocpp.md](ocpp.md),
+[priority-scheduling.md](priority-scheduling.md), and
+[load-balancing-stability.md](load-balancing-stability.md). This guide
+picks what to read from each depending on what you're building.
+
+---
+
+## 1. Pick your integration path
+
+| Goal | Mechanism | Complexity | Docs |
+|---|---|---|---|
+| Dashboards + simple automations in Home Assistant | MQTT + HA auto-discovery | low | §3 |
+| Feed mains current from HA (no physical mains meter) | REST `EM_API` | low–medium | §5 |
+| Custom script / Node-RED / non-HA platform | REST | medium | §4 |
+| Dynamic-pricing charging (Tibber, EnergyZero, ANWB) | REST or MQTT, triggered by HA automation | medium | §4 + §8 |
+| Public / shared / billed charging | OCPP 1.6j | high | §6 |
+| Two or more chargers on one house connection | RS485 master/slave | medium | §7 |
+| Subpanel protection (shared branch) | No integration needed — `MaxCircuit` setting | low | [guide-installer.md §11](guide-installer.md) |
+
+Multiple paths can co-exist. MQTT + REST + OCPP all run simultaneously.
+OCPP + internal load balancing are **mutually exclusive** — see §6.
+
+---
+
+## 2. Before you start
+
+Two preconditions for every integration:
+
+1. **The charger must be on your network and reachable.** `http://smartevse-<serial>.local/` or by IP. Pingable.
+2. **You need to decide on authentication.** By default the Web UI and REST API are open on the LAN (AuthMode=0). If you set AuthMode=1 every mutating REST call needs the `X-Auth-PIN` header. For home use AuthMode=0 is fine; for shared LAN it isn't. See [security.md](security.md).
+
+If you're feeding the charger from another system (HA sending mains
+current), enable that system first and verify it's reading values
+correctly before wiring it into the charger.
+
+---
+
+## 3. Home Assistant via MQTT
+
+The path of least resistance. The charger publishes every state change
+to MQTT and announces its entities via HA auto-discovery. No YAML
+required on the HA side — add the MQTT integration, point the charger
+at your broker, entities appear.
+
+### Setup
+
+1. Web UI → **MQTT Configuration**.
+2. Host = your broker IP / hostname.
+3. Port = 1883 (plain) or 8883 (TLS).
+4. Username / password if the broker requires them.
+5. Topic prefix — defaults to `smartevse-<serial>`. Change if you run
+   multiple chargers and want a common root.
+6. Save. The **Status** line should flip to "Connected" within a few seconds.
+7. In HA, entities appear under the device "SmartEVSE <serial>".
+
+### What you get out of the box
+
+- Current per phase (mains + EV), power, energy.
+- State, mode, error flags.
+- Charging active / enabled.
+- Override current, limits.
+- Solar state.
+
+All as sensors. Mode switching, override current, mains-current
+injection, MQTT command topics — all writable. Full reference:
+[mqtt-home-assistant.md](mqtt-home-assistant.md).
+
+### The two things people get wrong
+
+**Wrong topic prefix.** If HA shows no entities, the most common cause
+is that the charger publishes to `smartevse-1234/` and your HA MQTT
+integration filters on a different prefix. Match them.
+
+**Broker doesn't accept the client.** If the Web UI shows
+"Connected" → "Disconnected" flapping, check broker logs. Common causes:
+ACL not allowing the client, auth failing silently, TLS cert mismatch.
+
+### TLS
+
+If your broker requires TLS, upload the CA PEM in the MQTT panel. On
+Let's Encrypt brokers the default CA bundle usually works — leave the
+field empty. If you run your own CA, paste its PEM into the CA
+Certificate field.
+
+Note: TLS on the charger costs ~20–25 KB of RAM. Plain MQTT is fine on
+a trusted LAN.
+
+### Change-only publishing
+
+By default the charger publishes every 10 seconds even if nothing
+changed. With **Change-Only** enabled, it publishes only when a value
+changes (plus a heartbeat every N seconds to confirm liveness).
+Reduces MQTT traffic by 70–95%. Recommended.
+
+---
+
+## 4. REST API — when MQTT isn't enough
+
+When you need synchronous request/response, non-HA integration, or fine
+control over timing, use REST.
+
+### Anatomy
+
+- `GET /settings` — complete device state as JSON. Passwords redacted.
+- `POST /settings?<param>=<value>&...` — change settings. Body empty.
+- `GET /currents` — live phase currents.
+- `POST /currents?<param>=...` — **feed** mains or EV currents (see §5).
+- `POST /mode?<mode>&override_current=...` — change charging mode.
+- `GET /diag/status`, `/diag/start`, `/diag/stop` — diagnostic capture.
+
+Full endpoint catalogue: [REST_API.md](REST_API.md).
+
+### Auth
+
+If AuthMode=1, every `POST` needs a valid session. Clients obtain one by
+`POST /lcd-verify-password` first. `GET` endpoints are unprotected.
+
+On AuthMode=0 (default), no auth required. Anyone on the LAN can POST.
+That's why AuthMode=1 is worth enabling on anything shared.
+
+### Rate limits
+
+The REST server accepts up to 12 concurrent HTTP connections on v4
+hardware, 8 on v3. A browser typically opens 2–3; leave headroom. Don't
+spawn parallel POSTs at high rate — serialise.
+
+`POST /lcd-verify-password` is rate-limited (escalating backoff on
+failures). Five wrong PIN attempts in succession lock you out for 5
+minutes, six lock you out for 30.
+
+### Typical non-HA script pattern
+
+```
+# Dynamic-pricing charging with EnergyZero prices
+# Check price, decide target current, POST it.
+
+hourly_price = fetch_energyzero_price_for_current_hour()
+if hourly_price < 0.15:
+    current = 32   # full speed, cheap hour
+elif hourly_price < 0.25:
+    current = 16
+else:
+    current = 0    # don't charge
+
+POST http://smartevse-1234.local/mode?mode=1&override_current=${current*10}
+```
+
+Values in `override_current` are tenths of an amp — `160` means 16.0 A.
+Rounding to whole amps is standard.
+
+---
+
+## 5. Feeding mains current from Home Assistant (`EM_API`)
+
+The use case: your house has a smart meter or HA energy dashboard, but
+the charger has no physical mains meter. Instead of buying a Sensorbox,
+let HA push the current readings.
+
+### The plumbing
+
+1. Web UI → MainsMeter → set type to **API** (`EM_API`).
+2. HA reads phase currents from your smart meter (DSMR, HomeWizard,
+   Shelly Pro 3EM, etc.).
+3. HA automation POSTs to `/currents`:
+
+   ```
+   POST /currents?battery=1&L1=<amps>&L2=<amps>&L3=<amps>
+   ```
+
+   Values in amps (float). Signed: positive = import, negative = export.
+
+4. The charger treats this as if a physical meter reported those values.
+
+### The timing trap
+
+**The charger's API has a 10-second timeout.** If HA hasn't posted a
+fresh reading within 10 seconds, the charger marks the meter as stale
+and disables Smart/Solar mode.
+
+DSMR4 smart meters emit telegrams every 10 seconds. HA's DSMR
+integration receives them, but then has to run an automation that POSTs
+to the charger. Small delays add up. With DSMR4 + slow HA, you'll see
+intermittent stale-meter errors.
+
+Mitigations:
+- DSMR5 smart meters emit every 1 second. With DSMR5 + fast HA, you're
+  well within budget.
+- Run the reader → POST chain on a small dedicated device (Raspberry Pi
+  running a short Python loop), not through HA's full automation graph.
+- Cache the last telegram in HA and replay it every 5 seconds if no new
+  data arrived. Doesn't help solar accuracy but keeps the charger happy.
+
+### Don't set the charger's internal poll faster than this
+
+The charger polls its own meter ~every 2 seconds (Modbus path). The
+`EM_API` path depends on what you push. Pushing **more often than every
+2 seconds** doesn't buy you anything — the charger's control loop
+updates that fast, no faster.
+
+### Worked example — HA automation
+
+```yaml
+# Reads three HomeWizard P1 phase-current sensors, POSTs every 5 seconds
+- alias: Feed SmartEVSE mains currents
+  trigger:
+    platform: time_pattern
+    seconds: "/5"
+  action:
+    - service: rest_command.smartevse_currents
+      data:
+        l1: "{{ states('sensor.p1_current_l1') }}"
+        l2: "{{ states('sensor.p1_current_l2') }}"
+        l3: "{{ states('sensor.p1_current_l3') }}"
+```
+
+```yaml
+rest_command:
+  smartevse_currents:
+    url: "http://smartevse-1234.local/currents?battery=1&L1={{ l1 }}&L2={{ l2 }}&L3={{ l3 }}"
+    method: POST
+```
+
+For deeper treatment see [power-input-methods.md](power-input-methods.md).
+
+---
+
+## 6. OCPP backends
+
+OCPP 1.6j over secure WebSocket. Authorization, transactions, and
+charge-profile control delegated to a cloud backend. Use when:
+
+- You want public / shared charging with per-user billing.
+- Your energy provider (Tibber, Vandebron, etc.) requires OCPP for
+  dynamic tariff control.
+- You want centralised management of multiple chargers across sites.
+
+### What works, what's experimental
+
+| Feature | Status |
+|---|---|
+| BootNotification | stable |
+| Heartbeat | stable |
+| Authorize + StartTransaction + StopTransaction | stable |
+| MeterValues (energy reporting) | stable |
+| RemoteStart / RemoteStop | stable |
+| Smart charging profiles (CL-limit from backend) | stable |
+| FreeVend / AutoAuth (plug-and-charge with no RFID) | stable |
+| TLS WebSocket (wss://) | stable |
+| Reset / GetConfiguration / FirmwareUpdate | basic |
+
+Full reference: [ocpp.md](ocpp.md).
+
+### Setup
+
+1. Web UI → **OCPP Configuration**.
+2. Enable OCPP.
+3. Backend URL — your provider's WebSocket endpoint.
+4. Charge Box Id — the identifier your provider gave you.
+5. Password (auth_key) — your provider's token, if they use SP2 basic auth.
+6. Save.
+7. The **WS Status** should flip to "Connected" within ~20 seconds.
+
+### OCPP vs internal load balancing
+
+> [!IMPORTANT]
+> When OCPP is enabled **and** the backend sends a charging profile
+> (current limit), the internal Smart/Solar-mode load balancing is
+> **overridden**. The backend's limit wins. This is by design — an OCPP
+> backend operator expects full control.
+>
+> If you want both — solar-adaptive charging **and** OCPP billing —
+> configure the backend to send no-limit profiles (or a profile larger
+> than `MaxMains`) and let the charger's Smart/Solar mode do the
+> adaptation. Check with your provider; not all support no-profile mode.
+
+### Provider notes (from user reports)
+
+| Provider | Works? | Notes |
+|---|---|---|
+| Tibber | yes | Smart charging profiles via the Tibber-Pulse integration |
+| EnergyZero | yes | Native MQTT preferred over OCPP for most users |
+| E-Flux | yes | Standard SP2 auth; works with `auth_key` set |
+| Tap Electric | yes | Plug-and-charge with FreeVend idTag |
+| Monta | yes | Reported working; requires specific URL format |
+| ANWB Energy | not tested | Community reports mixed |
+| Public networks (Allego, Vattenfall) | not applicable | OCPP is the wrong protocol for end-user connection to public networks |
+
+Reports change over time. Check recent GitHub issues or the Tweakers
+thread before committing.
+
+### Authentication detail
+
+The `auth_key` field is the Basic Auth password used at the WebSocket
+handshake. It is never returned in `GET /settings` — only
+`auth_key_set: true/false`. When changing other OCPP settings, leave
+the `auth_key` field blank (or at the `••••••••` placeholder) to keep
+the stored value. Typing a new value replaces it.
+
+---
+
+## 7. Multi-charger (master/slave) configuration
+
+Wiring is in [guide-installer.md §12](guide-installer.md). This section
+covers configuration and priority.
+
+### Basic setup
+
+| Charger | `LoadBl` | MainsMeter | Notes |
+|---|---|---|---|
+| Master | 1 | configured on this module | Has the sensorbox / Modbus meter / P1 reader |
+| Node 1 | 2 | disabled | Inherits mains data from master via RS485 |
+| Node 2 | 3 | disabled | |
+| Node 3 | 4 | disabled | |
+| … | up to 8 | | |
+
+Each node's own `MaxCurrent` determines its branch limit. The master
+coordinates allocation so the **sum** across nodes never exceeds
+`MaxMains`.
+
+### Priority (who charges first when there isn't enough)
+
+Four strategies:
+
+| Strategy | Behaviour |
+|---|---|
+| **First-come** (default) | The first car to connect gets full current; later cars share leftover |
+| **Fair** | All active cars get equal share of available current |
+| **Rotating** | After `RotationInterval` minutes, cycles priority among connected cars |
+| **Manual** | Admin sets per-node priority (not user-facing) |
+
+Set on the master's Web UI → Load Balancing → Priority Strategy. Full
+semantics: [priority-scheduling.md](priority-scheduling.md).
+
+### Idle timeout
+
+If a car stays in state B (connected, not charging) for longer than
+`IdleTimeout` minutes, the master reclaims its current allocation and
+gives it to other charging cars. Prevents one "parked-but-plugged" car
+from blocking others.
+
+Default 30 minutes. Set to 0 to disable.
+
+### Master without Load Balancing
+
+Special case: one master with `LoadBl=1` and **zero** nodes is valid.
+It's effectively a standalone `LoadBl=0` master with identical behaviour
+— the load-balancing code runs but has nothing to allocate to. Useful
+when you plan to add nodes later without reconfiguring.
+
+---
+
+## 8. Timing and cadence — common traps
+
+Three different clocks, all independent:
+
+| Clock | Interval | Who sets it |
+|---|---|---|
+| Modbus meter poll | ~2 s | Firmware (fixed) |
+| `EM_API` push from HA | whatever you configure | You. 5 s is a reasonable default. |
+| MQTT publish | ~10 s (periodic) or on-change | Firmware (configurable) |
+| DSMR telegram from smart meter | 1 s (DSMR5) or 10 s (DSMR4) | Meter hardware |
+| HA automation tick | 1 s granularity | HA config |
+
+### The misconception
+
+"The charger needs data every 1 second." Wrong. The charger polls every
+2 seconds internally and times out at 10 seconds. Any cadence in that
+range works. Push more often than every 2 seconds and you're burning
+CPU for no benefit.
+
+### The real constraint
+
+- **Push < 2 s** — redundant, HTTP overhead negligible but wasteful.
+- **Push 2–5 s** — ideal for Smart/Solar control responsiveness.
+- **Push 5–10 s** — fine for Smart mode, marginal for Solar (slower
+  reaction to cloud events).
+- **Push > 10 s** — meter times out, mode disabled until fresh data.
+
+---
+
+## 9. Debugging integration issues
+
+### Nothing at all from MQTT / broker shows no connections
+
+1. Check the charger's Web UI MQTT status line.
+2. If "Disconnected": check broker host:port reachable from the
+   charger's IP. SSH into something on the same LAN and `telnet
+   broker-host 1883`.
+3. If TLS: check the CA cert matches the broker's certificate chain.
+4. If authenticated: check the username/password were saved (you'll see
+   `password_set: true` after save).
+
+### HA entities appear but stale
+
+- Check **Change-Only** is on for reasonable traffic, **off** if you
+  want forced periodic updates.
+- Check broker retain/QoS — some brokers drop messages under load.
+- Check HA's MQTT integration is actually subscribed to the topic
+  prefix. Match with the charger's configured prefix.
+
+### REST POST returns 401
+
+AuthMode=1, missing or expired session. Call `POST /lcd-verify-password`
+first, then repeat the call with the session cookie.
+
+### REST POST returns 403
+
+Origin / CSRF check failed. Only triggers on browser requests with a
+wrong `Origin:` header. Server-to-server calls without `Origin` are
+fine. If you're calling from a browser extension or cross-origin app,
+the charger is rejecting correctly.
+
+### REST POST returns 429
+
+Rate limit. Only on `/lcd-verify-password`. Wait the `Retry-After`
+seconds and try again. Don't retry in a tight loop.
+
+### OCPP shows Disconnected after a reboot
+
+Backend URL misconfigured, or backend auth rejected. Enable verbose
+logging (telnet 23) and watch the WebSocket handshake fail reason.
+Common: wrong `auth_key`, wrong URL path, TLS cert mismatch.
+
+### The diag panel auto-starts on page load
+
+Known-fixed in recent release. Press Stop once, reload — the backend
+now clears the profile to "off" on Stop so it won't re-attach.
+
+---
+
+## 10. Where next
+
+- **[mqtt-home-assistant.md](mqtt-home-assistant.md)** — full MQTT topic reference + HA entity list.
+- **[REST_API.md](REST_API.md)** — every endpoint, every parameter.
+- **[ocpp.md](ocpp.md)** — OCPP 1.6j message coverage.
+- **[priority-scheduling.md](priority-scheduling.md)** — priority-strategy semantics.
+- **[power-input-methods.md](power-input-methods.md)** — Sensorbox / P1 / Modbus / API comparison.
+- **[load-balancing-stability.md](load-balancing-stability.md)** — multi-node behaviour and edge cases.
+- **[Tweakers thread](https://gathering.tweakers.net/forum/list_messages/1648387)** — Dutch community, many HA / P1 / OCPP integration war stories.

--- a/docs/guide-owner.md
+++ b/docs/guide-owner.md
@@ -1,0 +1,472 @@
+# Owner guide
+
+Your charger is installed and reaches state A → B → C with a car plugged
+in. This guide covers the day-to-day: picking a mode, starting a
+session, reading the dashboard, managing RFID, and updating the
+firmware.
+
+If your charger isn't installed yet, see
+[guide-installer.md](guide-installer.md). If something doesn't work the
+way this guide describes, the
+[troubleshooting guide](troubleshooting.md) is the first stop.
+
+---
+
+## 1. The two interfaces you'll actually use
+
+### Web UI — `http://smartevse-<serial>.local/`
+
+Your daily driver. Works on phone and desktop. Shows live currents, lets
+you change modes, start/stop, adjust limits. No login needed by default.
+Set an LCD PIN and enable AuthMode to require authentication — see
+[security.md](security.md).
+
+### LCD + buttons — on the device itself
+
+Needed for first-time configuration (WiFi, meter selection, electrical
+parameters). After that, most owners rarely touch it. Good for when the
+Web UI is unreachable or when you're standing in the meter cabinet
+already.
+
+> [!TIP]
+> Everything on the LCD is also available in the Web UI. Everything in
+> the Web UI is **not** available on the LCD (some advanced settings are
+> web-only). If in doubt, use the web.
+
+### Which one for what
+
+| Task | LCD | Web UI |
+|---|---|---|
+| First-time WiFi setup | ✅ required | ❌ |
+| Select meter type / address | ✅ | ✅ |
+| Change mode (Normal/Smart/Solar) | ✅ | ✅ |
+| Start/stop a charge session | ✅ | ✅ |
+| Adjust current on the fly | ❌ (reboot required) | ✅ |
+| Schedule a future charge | ❌ | ✅ |
+| Add RFID cards | ❌ | ✅ |
+| Read per-phase current | limited | ✅ full |
+| Firmware update | ❌ | ✅ |
+| MQTT / HA configuration | ❌ | ✅ |
+| OCPP configuration | ❌ | ✅ |
+
+---
+
+## 2. The five modes
+
+Pick one based on what you want the charger to do when you plug in.
+
+| Mode | What it does | Use when |
+|---|---|---|
+| **Off** | Never charges, ignores the car | You're going away, want to be sure nothing starts |
+| **Normal** | Charges at a fixed current you set (Override Current) | You always want the same rate, don't care about solar or grid load |
+| **Smart** | Charges as fast as possible without overloading the grid connection | You want fast charging but respect the house main (3×25 A etc.) |
+| **Solar** | Charges only from excess solar production, matches PV surplus | You have solar, want to self-consume before exporting |
+| **Pause** | Mid-session pause, keeps the car connection alive | You want to interrupt a running session without unplugging |
+
+### Normal mode in detail
+
+- Set **Override Current** (e.g. 16 A). The charger asks the car for
+  that much, full stop.
+- Ignores the mains meter — will pull the full rate even if it trips the
+  house main. **Only safe if the branch is isolated from shared house
+  load, or if the charger current is well below the house main rating.**
+- The simplest mode. Works without any mains meter at all.
+
+### Smart mode in detail
+
+- Needs a working **MainsMeter**. Without it, the charger doesn't know
+  how loaded the house is.
+- Tracks `MaxMains` (the house main rating) and subtracts the current
+  house consumption. Charges with whatever's left, up to `MaxCurrent`.
+- Reacts to changes in ~2–10 seconds depending on meter source (Modbus
+  meter fastest, DSMR4 P1 meter slowest).
+- Will drop below 6 A? Pauses with `LESS_6A` until more power is
+  available. This is not a bug — 6 A is the Mode-3 minimum.
+
+### Solar mode in detail
+
+- Needs the MainsMeter **and** requires that the meter sees export (negative Isum).
+- Starts charging only when solar export exceeds `StartCurrent` (A per
+  phase) for `StopTime` minutes.
+- Stops (or downshifts) when export drops below zero for long enough.
+- `ImportCurrent` lets you top up from grid to reach at least 6 A total —
+  useful for marginal-solar days where pure-solar can't sustain 6 A.
+- The most-discussed mode on the forum. Tuning is car-dependent. See
+  §10 and the [solar-smart-stability.md](solar-smart-stability.md) deep
+  dive.
+
+### Off and Pause
+
+- **Off**: the charger is running, communicates with the car, but will
+  never close the contactors. Use when you're going away and want to be
+  sure nothing unexpected happens.
+- **Pause**: interrupts an active session without disconnecting the
+  car. Tap again (or hit Resume) to continue.
+
+---
+
+## 3. Starting a charge session
+
+### Plug-and-charge (no RFID)
+
+Default if you haven't configured RFID. Plug in, the car wakes up, and
+the charger starts per the current mode. No Web UI interaction needed.
+
+### RFID-protected
+
+Plug in → car waits. Swipe an enrolled card → charger authorizes → car
+starts charging. See §5 for card management.
+
+### From the Web UI (manual start in Normal mode)
+
+1. Plug the car in (state A → B).
+2. On the Web UI, click **Normal** (or the mode you want).
+3. Adjust **Override Current** with the slider if needed.
+4. Car transitions to state C, contactor closes, charging starts.
+
+### Scheduled / delayed
+
+Web UI → set **Start Time** and **Stop Time** → pick the mode → save.
+The charger waits until the start time, then runs in the chosen mode
+until the stop time.
+
+Useful for overnight off-peak billing (Tibber, EnergyZero, ANWB
+dynamic-pricing etc.) where you want charging between 01:00 and 05:00
+regardless of when the car was plugged in.
+
+The schedule repeats daily if you tick "daily repeat", otherwise it's
+one-shot.
+
+---
+
+## 4. Reading the dashboard
+
+The Web UI shows several numbers. Here's what each one means when
+something looks wrong.
+
+### State
+
+IEC 61851-1 state letter:
+
+| State | Meaning |
+|---|---|
+| A | No car connected |
+| B | Car connected, not ready to charge |
+| B1 | Car connected, charging disabled (pause / access off) |
+| C | Charging |
+| C1 | Charging, but car reported 1-phase to 3-phase transition needed |
+| D | Ventilation required (rare, mostly forklifts) |
+| E | Hard error — contactor stays open |
+| F | No CP signal — wiring problem or car disconnected unexpectedly |
+
+If the state stays B and never goes to C when you expect charging, the
+car doesn't see a valid pilot signal. See troubleshooting.
+
+### Mains currents (L1 / L2 / L3 / Isum)
+
+What the MainsMeter reports right now. Positive = import, negative =
+export (solar).
+
+- **Normal mode** ignores these.
+- **Smart mode** uses them to stay under `MaxMains`.
+- **Solar mode** waits for `Isum` to go sufficiently negative before
+  starting.
+
+### EV currents (L1 / L2 / L3)
+
+What the charger is actually delivering right now. If you set 16 A and
+the EV current shows 8 A, either the car chose to draw less (most EVs
+can slow down below the offered current) or PP detected a 16 A cable
+and you're on a 32 A setpoint that the cable caps.
+
+### Charge current / Override Current
+
+What the charger is *offering* the car via CP PWM. The car may draw
+less. If EV current ≪ offered, that's usually car behavior, not a
+charger fault.
+
+### Solar state (Solar mode only)
+
+- `SolarStopTimer`: seconds remaining before solar mode gives up on
+  insufficient export.
+- `StartCurrent` / `StopTime` / `ImportCurrent`: the thresholds you
+  configured. See §10.
+
+---
+
+## 5. RFID card management
+
+### Enable RFID
+
+Web UI → RFID reader section → set reader type. Supported readers listed
+in [configuration.md](configuration.md).
+
+### Add a card
+
+1. Web UI → RFID → click **Add**.
+2. Swipe the card on the reader within the prompt window.
+3. The card UID appears. Optionally label it (e.g. "Piet's car").
+4. Save.
+
+### Remove a card
+
+Web UI → RFID → click the trash icon next to the card.
+
+### Bulk enrolment
+
+Upload `rfid.txt` via the `/update` page. Each line is one UID,
+hex-formatted (e.g. `04A1B2C3D4E5F6`). Up to 100 cards.
+
+### Forgotten which card is which
+
+UIDs are displayed on the Web UI during authorization attempts and in
+the OCPP logs. Swipe each candidate, watch the UI, label accordingly.
+
+### Auto-auth (OCPP FreeVend)
+
+If you have OCPP enabled and want no-card-needed authorization, enable
+**Auto-authorize** with a default idTag. Every plug-in is auto-approved
+with that tag. Use at your own risk on public chargers — anyone who
+plugs in draws on your OCPP contract.
+
+---
+
+## 6. Firmware updates
+
+> [!IMPORTANT]
+> Read the release notes before updating. Some updates require a
+> one-time re-configuration (e.g. when a setting's NVS key format
+> changes). Most don't.
+
+### Standard flow
+
+1. Download `firmware.signed.bin` from the
+   [releases page](https://github.com/basmeerman/SmartEVSE-3.5/releases).
+2. Web UI → `/update` (or click the Update link).
+3. If AuthMode is on, the UI prompts for the LCD PIN first.
+4. Choose the file → upload.
+5. The device reboots. Web UI becomes reachable again in ~20 seconds.
+
+### Debug builds
+
+If a maintainer or contributor sends you a debug build (for diagnosing
+a specific issue), it's named `firmware.debug.signed.bin`. Same upload
+flow. Debug builds run telnet-accessible verbose logging — useful for
+capturing a bug report, not for everyday use.
+
+### Something went wrong after update
+
+Roll back: download the previous release version, upload it. NVS
+settings usually survive downgrades but not always — if behaviour
+looks corrupted, do a settings reset (see [configuration.md](configuration.md)).
+
+Firmware updates will **not** reset your WiFi, RFID cards, or your LCD
+PIN. Those survive reflashing.
+
+---
+
+## 7. Common adjustments
+
+### "I got a new electricity contract with a different house rating"
+
+Change `MaxMains`. LCD menu → Electrical → MaxMains. Or Web UI →
+Settings → Current Main. Set to the new rating minus 1–2 A of margin.
+Takes effect immediately, no reboot.
+
+### "Solar mode isn't starting even when I see export"
+
+Check `StartCurrent`. Default is 4 A/phase — that's 4 × 230 = ~920 W/phase
+of sustained export needed before it will engage. On a cloudy day with
+fluctuating export, the threshold may never be met for the required
+time. Lower `StartCurrent` to 2 A (requires ~460 W/phase). Trade-off:
+more false starts, more cycling of the contactor.
+
+### "Solar mode cycles on/off every few minutes"
+
+Increase `StopTime` (minutes of below-threshold before stopping). Default
+is often 10 minutes; if your solar fluctuates heavily, try 15 or 20. The
+contactor will stay closed through short cloud gaps.
+
+See [solar-smart-stability.md](solar-smart-stability.md) for the full
+tuning guide.
+
+### "Smart mode is pulling too much, tripping something"
+
+Check `MaxMains` first. If that's correct, check that the MainsMeter is
+actually reporting accurate current (Web UI → Mains currents — do they
+match a clamp-meter reading on the main cable?). A meter in error
+state (stale data, wrong CT orientation) will make Smart mode overshoot.
+
+### "I want to charge with less current for a night"
+
+Web UI → Normal mode → set Override Current to what you want (e.g. 10 A).
+Valid during that session only. Revert next time by picking Smart or
+Solar again.
+
+### "The car charges on one phase when I want three"
+
+- Check whether your car actually supports 3-phase AC charging
+  (many don't — Zoe original, older Kona, some Ioniqs are 1-phase AC
+  only despite 3-phase looking physically available).
+- If it does, check `EnableC2`. If set to "Always Off", the second
+  contactor is off and you're forced to 1-phase.
+- If your EV is correctly 3-phase-capable and `EnableC2` is "Always On"
+  but the car still chooses 1-phase, that's the car's choice — some
+  cars pick 1-phase below a certain offered current. Offer 16 A/phase
+  (3×16 A = 11 kW) to get 3-phase on most cars.
+
+---
+
+## 8. Access control
+
+Three layers of "who can do what":
+
+### Car-side access
+
+- **RFID reader present + enrolled card required**: only enrolled cards
+  can start a session.
+- **No RFID**: plug-and-charge.
+
+### Web UI access
+
+- **AuthMode = 0 (default)**: Web UI is open to anyone on your LAN.
+- **AuthMode = 1**: Web UI requires LCD-PIN verification for mutating
+  actions. The PIN is stored on the device (`LCDPin` setting). After a
+  correct PIN, the session stays authenticated for 30 minutes idle.
+
+See [security.md](security.md) for the full access-control model. For routine home use, AuthMode=0 is fine. For shared LAN
+(apartment, office), enable AuthMode=1 and set a non-zero PIN.
+
+### OCPP-side access
+
+If OCPP is enabled and configured with a backend (Tibber, E-Flux,
+Tap Electric, Monta etc.), authorization is delegated to the backend.
+An unknown idTag returns `Invalid` and the session doesn't start.
+
+---
+
+## 9. Multi-charger setup (master/slave)
+
+If you have two or more chargers on one house connection, one is the
+master, the others are nodes (slaves). They share the MainsMeter reading
+and coordinate so that neither exceeds `MaxMains`.
+
+Quick primer:
+
+- The **master** is the one with `LoadBl=1`. It has the MainsMeter
+  attached.
+- Each **node** has `LoadBl=2, 3, 4…` (one per node, sequential).
+- All modules are wired to the same RS485 bus (A↔A, B↔B, GND↔GND).
+
+Day-to-day you mostly interact with the master's Web UI — it knows what
+all nodes are doing. Each node has its own Web UI but shows its own
+state, not the cluster state.
+
+Detailed wiring in [guide-installer.md](guide-installer.md) §12.
+Priority allocation (who gets current first when there's not enough for
+everyone) in [priority-scheduling.md](priority-scheduling.md).
+
+---
+
+## 10. Solar mode tuning — first-time setup
+
+For most houses, the defaults are close enough. Tune only if the mode
+misbehaves.
+
+### The three knobs
+
+| Setting | What it does | Default | Lower this if | Raise this if |
+|---|---|---|---|---|
+| `StartCurrent` (A/phase) | How much export sustained before starting | 4 A | You want to catch more marginal export | False starts on brief sun gaps |
+| `StopTime` (minutes) | Below-threshold duration before stopping | 10 min | You want quick response to clouds | Too much cycling on/off |
+| `ImportCurrent` (A) | Grid top-up to reach 6 A minimum charge | 0 A | You want to guarantee 6 A even with less solar | You want pure-solar only |
+
+### Common pattern on Dutch summer day
+
+`StartCurrent=3 A`, `StopTime=15 min`, `ImportCurrent=0`. Will start
+around noon, run through mid-afternoon, survive short cloud periods,
+stop cleanly when sun drops below the threshold at ~17:00.
+
+### Common pattern on marginal-solar winter day
+
+`StartCurrent=2 A`, `StopTime=20 min`, `ImportCurrent=2 A`. Will grab
+whatever the array produces and top up to 6 A from grid so charging
+actually happens. Accept you're not 100% self-consumption, you're
+~80%+.
+
+### Car-specific quirks
+
+Some EVs don't like being offered less than 6 A/phase for extended
+periods — they drop the session. Others handle it fine. If your car
+keeps disconnecting in solar mode, raise `ImportCurrent` so the minimum
+offered stays ≥ 6 A.
+
+See [solar-smart-stability.md](solar-smart-stability.md) for the deep
+dive, including phase-switching (1P↔3P) and the `EnableC2=AUTO` option.
+
+---
+
+## 11. Home Assistant / MQTT / REST — overview
+
+If you run Home Assistant or want scripting, see
+[guide-integrator.md](guide-integrator.md). Short version:
+
+- **MQTT**: the charger publishes every change and auto-discovers HA
+  entities. Topic prefix configurable. See
+  [mqtt-home-assistant.md](mqtt-home-assistant.md).
+- **REST**: all settings exposed via `/settings` (GET/POST), currents
+  via `/currents`, modes via `/mode`. See
+  [REST_API.md](REST_API.md).
+- **OCPP**: WebSocket backend integration. See [ocpp.md](ocpp.md).
+
+Owner-scoped note: for home use where you're the only user, MQTT + HA
+covers 95% of what you'd want integration-wise. OCPP is mainly for
+public-charger setups and ToU-billing integrations.
+
+---
+
+## 12. Backup and restore
+
+The device stores configuration in flash NVS. There is **no one-button
+export**. If you reflash or replace the PCB:
+
+- WiFi password: re-enter via LCD.
+- MaxMains / MaxCurrent / MaxCircuit / meter selection: re-enter via LCD.
+- RFID cards: re-upload via `rfid.txt`.
+- MQTT / OCPP settings: re-enter via Web UI.
+
+Keep a copy of your settings somewhere (a text file, a printout of the
+Web UI's settings panel). The LCD menu has a compact summary screen
+showing the main values; photograph it.
+
+A factory reset (clears everything) is available via LCD menu →
+Settings → Reset. Use before hand-off if selling the device.
+
+---
+
+## 13. When things go wrong
+
+| Symptom | First check | Doc |
+|---|---|---|
+| Car plugged in but never charges | State on the LCD / Web UI | [troubleshooting.md](troubleshooting.md) |
+| Solar mode cycles on/off | `StartCurrent` + `StopTime` | [solar-smart-stability.md](solar-smart-stability.md) |
+| Smart mode trips the main | `MaxMains` value, MainsMeter reading accuracy | [troubleshooting.md](troubleshooting.md) |
+| No MQTT entities in HA | Topic prefix, broker reachability, discovery prefix | [mqtt-home-assistant.md](mqtt-home-assistant.md) |
+| Web UI rejects your firmware upload | LCD PIN not verified / unsigned file | [security.md](security.md) |
+| Diag panel shows "Capturing" forever | Press Stop | known-fixed bug (recent release) |
+| LCD button does nothing | LCD PIN lock active | enter PIN via Web UI |
+
+For telnet debug logs (verbose runtime output), the charger runs a
+telnet server on port 23 by default — useful when filing a bug report.
+Connect with any telnet client.
+
+---
+
+## 14. Where next
+
+- **[guide-integrator.md](guide-integrator.md)** — if you run Home Assistant or want REST/MQTT/OCPP.
+- **[configuration.md](configuration.md)** — full LCD menu reference.
+- **[solar-smart-stability.md](solar-smart-stability.md)** — solar mode
+  deep dive.
+- **[Tweakers "Zelfbouw Laadpaal" thread](https://gathering.tweakers.net/forum/list_messages/1648387)** —
+  Dutch community support.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,289 @@
+# Security
+
+This firmware runs on your LAN and controls a 32 A circuit. The
+security defaults and features here are what the operator controls.
+
+For defaults-only summary see §2. For the full model see §3 onwards.
+
+---
+
+## 1. Threat model
+
+Realistic threats:
+
+| Threat | Mitigation |
+|---|---|
+| Malicious website triggers charge commands via CSRF | Origin check (§5) |
+| Guest on your WiFi brute-forces the LCD PIN | Rate-limited PIN verify (§6) |
+| Guest on your WiFi flashes hostile firmware | Signed firmware + LCD-PIN gate (§7) |
+| Guest on your WiFi reads your Wi-Fi / MQTT / OCPP secrets | Redacted GET endpoints (§4) |
+| Attacker with LAN + PIN steals session tokens | 30-min session timeout (§6) |
+| Attacker with physical USB access | Out of scope — USB flash bypasses all |
+
+Not in scope:
+
+- Attackers with physical access to the device. A malicious actor at
+  your meter cabinet can replace the whole charger.
+- Attackers on the WAN side if the Web UI is port-forwarded. Don't do
+  that. The Web UI is designed for LAN use.
+- Denial-of-service on the local network.
+
+---
+
+## 2. Defaults
+
+Out of the box, on a fresh install:
+
+| Setting | Default | Secure? |
+|---|---|---|
+| AuthMode | 0 (Off — no auth required on Web UI) | Fine on a trusted home LAN. Enable for shared LAN. |
+| LCDPin | 0 (unset) | Must set a PIN (non-zero) to use AuthMode=1 |
+| Firmware upload | Signed only | Yes — unsigned rejected |
+| OCPP auth key | Not returned in GET /settings | Yes — redacted |
+| MQTT password | Not returned in GET /settings | Yes — redacted |
+| Origin / CSRF check | Active when AuthMode=1 | Yes |
+
+If you're on a shared LAN (apartment Wi-Fi, office, rented space),
+enable AuthMode=1. On your own home LAN where you trust every
+connected device, AuthMode=0 is fine.
+
+---
+
+## 3. AuthMode — the master switch
+
+`AuthMode` is a persisted setting with two values:
+
+| Value | Behaviour |
+|---|---|
+| `0` (Off, default) | Web UI and REST API are open to anyone on the LAN. No authentication required. Backward-compatible with pre-auth integrations (existing HA setups, curl scripts). |
+| `1` (Required) | Every mutating endpoint (`POST /settings`, `POST /mode`, `POST /update`, etc.) requires a valid session. Session obtained via `POST /lcd-verify-password`. |
+
+### Enabling AuthMode
+
+1. Set a non-zero LCDPin first. Web UI → settings → LCD PIN, or via
+   the LCD menu.
+2. Web UI → Security → AuthMode → **Required**.
+3. Save. The Web UI will redirect to a PIN prompt.
+
+### Disabling AuthMode
+
+1. LCD menu → settings → AuthMode = Off.
+2. Or via the Web UI while currently authenticated.
+
+> [!IMPORTANT]
+> Never enable AuthMode=1 without first setting a non-zero LCDPin. The
+> Web UI prevents this, but if you bypass the UI (via MQTT / REST) you
+> can lock yourself out. Recovery requires physical LCD access.
+
+### Effect on existing integrations
+
+- **Home Assistant via MQTT**: unaffected. MQTT is a separate channel
+  with its own auth.
+- **HA via REST**: breaks until HA sends `X-Auth-PIN` header. If you
+  rely on HA calling REST, stay on AuthMode=0 or add the header.
+- **OCPP backend**: unaffected. OCPP is a separate outbound WebSocket.
+- **Browser**: prompts for PIN once per 30-minute session.
+
+---
+
+## 4. Secret redaction in GET /settings
+
+Three secrets are configured through the Web UI but never returned in
+the settings JSON:
+
+| Secret | What you get instead | Upload semantics |
+|---|---|---|
+| MQTT password | `mqtt.password_set: true/false` | Empty or `••••••••` placeholder = keep existing. Any other value = replace |
+| OCPP auth_key | `ocpp.auth_key_set: true/false` | Same — empty or bullets keep existing |
+| WiFi password | not exposed at all | Set via LCD WiFi menu only |
+
+This means if a malicious script on your LAN calls `GET /settings`, it
+learns only **that** a MQTT password is set, not what it is.
+
+### Why the bullets
+
+The Web UI displays `••••••••` in password fields when a secret is
+configured. If the user saves without retyping, the frontend and
+backend both skip the field (don't overwrite). Prevents the common
+"save settings → lose password" bug.
+
+---
+
+## 5. CSRF / Origin check
+
+Only active when AuthMode=1. When the Web UI / API receives a browser
+request with an `Origin:` header, the header must match the device's
+own hostname or IP. Cross-origin POSTs from malicious websites are
+rejected with 403.
+
+Non-browser clients (curl, Python requests, HA REST command) usually
+don't send `Origin:` — they're unaffected.
+
+For fully technical details see the header-matching logic in
+`src/http_auth.c::http_auth_origin_matches`.
+
+---
+
+## 6. PIN rate limiter
+
+`/lcd-verify-password` has an escalating backoff to defeat brute-force
+of the 4-digit PIN.
+
+| Consecutive failures | Cooldown |
+|---|---|
+| 1–2 | None |
+| 3 | 10 s |
+| 4 | 60 s |
+| 5 | 5 min |
+| 6+ | 30 min (cap) |
+
+During cooldown, the endpoint returns **429 Too Many Requests** with a
+`Retry-After: <seconds>` header and does **not** attempt the PIN
+compare (avoids timing side-channel). A successful PIN clears the
+counter. An idle period > 10 minutes also clears if no cooldown is
+active.
+
+At steady state, an attacker gets ~50 attempts/day. Full 10,000-PIN
+space takes ~200 days — defeats scripted brute-force.
+
+---
+
+## 7. Firmware signature verification
+
+The OTA upload endpoint (`/update`) only accepts firmware images signed
+with one of the trusted public keys baked into the running firmware.
+Unsigned `firmware.bin` / `firmware.debug.bin` is rejected on release
+builds.
+
+### Multi-key setup
+
+Two trusted keys are embedded:
+
+| Key | Purpose |
+|---|---|
+| Key 0 | Community / reference builds |
+| Key 1 | Additional release channel |
+
+A firmware image is accepted if it's signed by **any** of the trusted
+keys. This lets release channels rotate without re-flashing every
+device to swap keys.
+
+### Debug-build unsigned uploads
+
+Debug builds (compiled with `DBG=1`) offer an additional path for local
+iteration: `firmware.bin` and `firmware.debug.bin` can be uploaded
+unsigned **when** the LCD PIN is set (non-zero) **and** has been
+verified in the current Web-UI session. Physical-presence auth stands
+in for the signature.
+
+Release builds never accept unsigned uploads. This is a hard
+compile-time distinction, not a runtime toggle.
+
+### Why this matters
+
+Without this, a LAN attacker could flash hostile firmware via plain
+HTTP with no signature and no authentication — unauthenticated RCE.
+The signature + LCD-PIN gate closes that hole.
+
+### Flashing a new firmware version
+
+Download `firmware.signed.bin` from the
+[releases page](https://github.com/basmeerman/SmartEVSE-3.5/releases)
+and upload via the Web UI. The signature is validated on-device before
+the boot partition is swapped. Invalid signatures are rejected and the
+target partition is erased.
+
+---
+
+## 8. Session timeout
+
+After `POST /lcd-verify-password` succeeds, the authenticated session
+(`LCDPasswordOK`) stays active for 30 minutes of idle time. Every
+successful authenticated request resets the clock. 30 minutes without
+any authenticated activity → the session expires and the next request
+returns 401.
+
+30 minutes is hardcoded; future releases may make it configurable.
+
+The session is a server-side flag, not a signed cookie. This means:
+
+- A single authenticated session covers **all** clients on the LAN —
+  once someone verifies the PIN, anyone else on the LAN has 30 minutes
+  to act. Matches the "trusted LAN" assumption.
+- Future work (Phase 3 of the auth plan) adds per-client HMAC cookies
+  if the threat model demands per-client isolation.
+
+---
+
+## 9. MQTT / OCPP — channel-specific notes
+
+### MQTT
+
+- Password in transit: plaintext by default. Enable TLS on the broker
+  if secrets matter.
+- Topic prefix is not a secret — anyone who can read the broker can
+  read your device's messages regardless of prefix.
+- Change-Only publishing (enabled by default in recent releases)
+  reduces information exposure: less traffic, fewer periodic secret
+  dumps. Note: no secret is ever in an MQTT publish either way; this
+  is about volume, not disclosure.
+
+### OCPP
+
+- TLS WebSocket (`wss://`) recommended. Plain `ws://` works but sends
+  auth_key in the clear.
+- The `auth_key` field is the Basic Auth password for the WebSocket
+  handshake. Treat it as secret. It's never logged to telnet or
+  returned in `/settings`.
+- RemoteStart / RemoteStop from the backend are unconditionally
+  obeyed when OCPP is enabled — ensure your OCPP backend's own access
+  control is tight.
+
+---
+
+## 10. Logging — what's safe to share
+
+### Telnet debug log
+
+Full runtime log. **Do** share when filing bug reports. **Check for
+secrets before posting publicly** — the log does not normally include
+passwords, auth keys, or WiFi credentials (these are explicitly
+redacted in firmware), but your MQTT topic structure, IP addresses,
+and behaviour patterns are visible.
+
+### /settings JSON
+
+Safe to share. Passwords (MQTT, WiFi, OCPP auth_key) are all redacted
+to `_set: bool` booleans. You can post this verbatim.
+
+### Boot log
+
+Safe. The firmware explicitly redacts the generated MQTT password's
+hash to "first 4 chars + ellipsis" (security fix C-5). Full password
+never appears.
+
+---
+
+## 11. What to do if you suspect compromise
+
+1. **Physical access.** Power off the charger at the main breaker.
+2. **Settings wipe.** Factory reset via LCD menu → Settings → Reset.
+   Clears NVS including WiFi, LCDPin, MQTT password, OCPP auth_key.
+3. **Firmware reflash via USB.** Bypasses OTA, guarantees known
+   firmware. See [building_flashing.md](building_flashing.md).
+4. **Rotate external secrets.** MQTT broker password, OCPP auth_key,
+   WiFi password (if the WiFi was compromised, the whole network
+   needs attention, not just this device).
+5. **Check the main breaker history.** Any charging sessions you
+   didn't initiate?
+
+---
+
+## 12. Reporting security issues
+
+Please use GitHub's private vulnerability reporting on the repository
+rather than a public issue. Private report → maintainer gets notified →
+fix developed → coordinated disclosure.
+
+For architectural context on security reviews see
+[docs/security/](security/) (internal working documents).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,382 @@
+# Troubleshooting
+
+Symptom-indexed. Start at the symptom, work through the triage steps.
+If nothing here matches, capture a telnet debug log (§11) and open an
+issue or ask on the
+[Tweakers thread](https://gathering.tweakers.net/forum/list_messages/1648387).
+
+---
+
+## 1. Car plugged in but never starts charging
+
+State on the LCD / Web UI stays at B.
+
+| Check | How | If bad |
+|---|---|---|
+| Car is authorised to charge | Web UI: Access = ON? RFID swiped? | Enable access, swipe card, or disable RFID gate |
+| Mode is not OFF or PAUSE | Web UI top mode indicator | Switch to Normal / Smart / Solar |
+| In Smart/Solar: enough power available | Web UI → Mains currents | Lower `MaxMains` if already at limit; in Solar mode wait for export |
+| In Smart mode: `MaxMains` is not 0 | Web UI → Settings | Set to actual house main rating |
+| CP PWM is driving the pilot | Scope on CP pin, state B should show ±12 V 1 kHz PWM | If flat +12 V, CP is not being driven — possible wiring fault or hardware issue |
+| PP cable resistor detected | Web UI → cable limit shows expected A | If cable limit is wrong, check PP resistor (220 Ω = 32 A, 680 Ω = 20 A, 1.5 kΩ = 13 A) |
+| Car supports AC charging at offered current | Car's own display / app | Some cars refuse offers below 6 A; some drop session below 4 A sustained |
+
+**If the state goes B → C briefly then back to B**, the car rejected
+the session after starting. Usually a CP signal issue (noise on long
+unshielded cables — see [guide-installer.md §6](guide-installer.md)) or
+the car's own fault (battery full, thermal limit).
+
+---
+
+## 2. Charging stops randomly mid-session
+
+Short (seconds) interruptions, then resumes.
+
+| Check | Cause |
+|---|---|
+| CP cable length > 20 m, unshielded | Electromagnetic noise triggers car to disconnect |
+| Contactor is a silent / AC-DC type | Chattering contactor opens briefly |
+| RCD trips intermittently | Car's own DC leakage approaches the 30 mA threshold; Type A RCD is borderline |
+| House brownout pulls mains below tolerance | Session drops until power stabilises |
+| In Smart mode, mains current spiked above `MaxMains` | Charger cut the EV side to protect the house main |
+
+The most common cause on long-run installs: **unshielded CP cable**.
+Replace with SFTP CAT6/7, shield bonded to PE at the meter-cabinet
+side only. See [guide-installer.md §6](guide-installer.md).
+
+---
+
+## 3. Solar mode cycles on/off
+
+Charging starts, runs for 1–3 minutes, stops. Repeats.
+
+| Check | Fix |
+|---|---|
+| `StopTime` too short for cloud events | Raise to 15–20 minutes |
+| `StartCurrent` too high for your array | Lower. 2–3 A/phase is a reasonable floor |
+| Car won't accept < 6 A offered | Set `ImportCurrent` so the minimum stays ≥ 6 A |
+| Some cars need 6 A × 3 phases = 18 A min | Lower pseudo-single-phase with `EnableC2=AUTO` if hardware supports C2 |
+| Sensorbox CT clamps on wrong phases | Verify with kettle / dryer — one appliance should show on one phase only |
+
+See [solar-smart-stability.md](solar-smart-stability.md) for the full
+tuning guide.
+
+---
+
+## 4. Solar mode never starts
+
+Export visible on the smart meter, but charger doesn't engage.
+
+| Check | Cause |
+|---|---|
+| Mode is Solar on the Web UI | Easy miss — confirm it's not still Normal/Smart |
+| Mains meter shows negative Isum during export | If positive, CT clamp orientation is wrong — flip it |
+| `StartCurrent` threshold not reached | Lower `StartCurrent` |
+| Export was transient (< `StopTime` threshold) | Wait longer, or lower `StopTime` |
+| Car is in state B but `Access` is Off | Enable access or swipe RFID |
+| `HomeBatteryCurrent` feeds falsely low export | If you're pushing HA battery data, check the sign and path |
+
+---
+
+## 5. Smart mode trips the house main
+
+The charger pulls too much and the main breaker pops.
+
+| Check | Cause / Fix |
+|---|---|
+| `MaxMains` value matches your main rating minus margin | Set to rating − 1–2 A (e.g. 23 A on a 3×25 A supply) |
+| MainsMeter is actually reporting real data | Web UI currents — compare to clamp meter |
+| Meter poll cadence is fast enough | Modbus: 2 s native. API-fed: must be < 10 s between updates |
+| Non-EV load spiked faster than control loop | Control loop responds in ~2–5 s; a 10 kW surge from electric shower can outrun it |
+| Meter shows wrong phase mapping | A kettle on L1 should appear on L1 in the charger's display; if not, CT to phase wiring is swapped |
+
+In practice, leave `MaxMains` at `rating − 2 A` to give the control
+loop headroom for fast transients.
+
+---
+
+## 6. Wrong or missing current values
+
+Mains or EV currents show zero, wrong sign, or obviously wrong magnitude.
+
+### Zero on all phases
+
+| Cause | Fix |
+|---|---|
+| Meter type set to None | Web UI → select your meter type |
+| Modbus address wrong | Meter default 1 collides with SmartEVSE cluster (1–10). Set meter to 11+ |
+| RS485 wiring A↔B swapped | Verify with a multimeter in DC-volts mode (idle line has ~2.5 V differential) |
+| Cat5 run not twisted-pair for A/B | Redo with one twisted pair for A+B (green + green/white etc.) |
+| Wrong meter type selected | Check the actual meter model — generic "Modbus" is not valid, pick specific type |
+
+### Correct magnitude, wrong sign (import shown as export or vice versa)
+
+| Cause | Fix |
+|---|---|
+| CT clamp arrow points toward grid | Flip the clamp. Arrow should point toward the load (house) |
+| Eastron meter fed from below (Dutch cabinet) | Change meter type from "Eastron" to "Inverted Eastron" |
+| Wrong phase mapped | Swap CT secondary wires at the Sensorbox |
+
+### Currents roughly right but one phase wildly off
+
+| Cause | Fix |
+|---|---|
+| CT clamp not fully closed on the wire | Open and re-close until the halves click together |
+| CT clamp on wrong phase | Rewire to correct phase |
+| One CT wire loose at the Sensorbox terminal | Retighten |
+
+---
+
+## 7. Contactor chatters or welds
+
+Contactor buzzes, rapid-clicks, or stays closed after session ends.
+
+**Almost always**: the contactor is a silent / AC-DC / energy-efficient
+type not compatible with this firmware's coil drive.
+
+| Contactor | Compatible? |
+|---|---|
+| Iskra IKA432-40 | Yes |
+| Hager ESC440 (no "S" suffix) | Yes |
+| Chint NC1-4025 | Yes |
+| Siemens 3RT20xx-xBBx0 | Yes |
+| ABB ESB series | No — silent, won't work |
+| Hager ESCxxx**S** (S = silent) | No |
+| Any "AC-DC" branded coil | No |
+
+Welded contacts from a compatible contactor that's been run beyond its
+life cycles: replace the contactor. Contactor lifetime is finite —
+40 A AC-1 contactors are rated for ~100,000 switch cycles. A
+solar-cycling install that opens/closes 10× per day reaches that in
+~27 years, so most welds are from incompatible coil drive, not wear.
+
+---
+
+## 8. MQTT / Home Assistant entities missing or stale
+
+### Nothing appears in HA
+
+| Check | Fix |
+|---|---|
+| Web UI MQTT status = Connected | If Disconnected, check broker host/port/creds |
+| Topic prefix matches HA's MQTT integration filter | Match prefixes exactly |
+| HA's MQTT integration is enabled | Settings → Integrations → MQTT → present and green |
+| Broker ACL permits the client | Check broker logs |
+
+### Connection drops repeatedly
+
+| Cause | Fix |
+|---|---|
+| TLS enabled but CA cert wrong | Upload correct CA PEM or disable TLS for testing |
+| Client ID conflict (two devices with same serial) | Shouldn't happen, but check broker |
+| Complex password with special chars | Known issue — some brokers mishandle. Try a simple password first, work up |
+| Broker rate-limits or kicks idle clients | Reduce `Heartbeat` interval; enable Change-Only |
+
+### Entities appear but never update
+
+| Cause | Fix |
+|---|---|
+| `Change-Only` on, broker dropped retained message | Toggle a value to force republish |
+| HA discovery prefix mismatch | `homeassistant/` is the HA default; make sure the charger uses it |
+
+See [mqtt-home-assistant.md](mqtt-home-assistant.md) for the full topic
+layout.
+
+---
+
+## 9. OCPP backend stays Disconnected
+
+### WebSocket never connects
+
+| Check | Cause |
+|---|---|
+| Backend URL correct | Path matters — some providers need `/ocpp/<cbid>` suffix |
+| Charge Box Id matches what provider issued | Copy-paste from provider portal |
+| `auth_key` set (if SP2 auth) | Verify via `auth_key_set: true` in /settings |
+| Firmware supports `wss://` | Yes, TLS WebSocket supported — check CA cert if it's self-signed |
+| Network firewall blocks outbound 443 | Test from a LAN device: `curl -v wss://backend/...` |
+
+### Connects but then disconnects after BootNotification
+
+Backend rejected the boot. Check backend logs. Common causes:
+
+- Unknown charge point ID (not provisioned on backend side)
+- Firmware version reported doesn't meet backend's minimum
+- Backend's OCPP configuration requires capabilities this firmware doesn't advertise
+
+### Works for a few minutes then drops
+
+Keepalive / heartbeat misconfigured. Backend's heartbeat interval
+should match the charger's. Typically 300 s. A value of 60 s or less
+on a bad network will trip every network hiccup.
+
+---
+
+## 10. Firmware upload fails
+
+### "Unsigned firmware rejected"
+
+Default policy on release builds. Options:
+
+1. Upload `firmware.signed.bin` from the releases page.
+2. If running a debug build (`DBG=1`), set an LCD PIN and verify it
+   via the Web UI first. Then unsigned `firmware.bin` /
+   `firmware.debug.bin` upload is accepted (debug builds only; release
+   builds always require signed).
+
+See [security.md](security.md) for the model.
+
+### 411 Length Required
+
+Some POSTs from older clients omit Content-Length. Use a modern
+browser or explicitly set `Content-Length: 0` on curl POSTs. Fixed in
+all recent Web UI builds.
+
+### Too many connections (9), rejecting new connection
+
+Too many concurrent HTTP connections. Usually your browser opened
+multiple tabs, or a client is leaking connections. Close extras. If it
+persists, reboot the charger.
+
+### Signature valid but device won't boot new version
+
+Unusual. The partition was written and validated but the new firmware
+failed to boot. Device auto-rolls back to the previous good partition.
+Check telnet log for the exact failure (stack trace, abort reason).
+
+---
+
+## 11. Capturing a debug log
+
+The device runs a telnet server on port 23 with verbose runtime
+logging. Connect with any client:
+
+```
+telnet smartevse-<serial>.local
+```
+
+Or by IP:
+
+```
+telnet 192.168.1.42
+```
+
+### What to collect for a bug report
+
+- The telnet output covering the problem's reproduction.
+- The Web UI's **settings** JSON: `http://smartevse-<serial>.local/settings`.
+  Passwords are redacted.
+- Firmware version (LCD or Web UI footer).
+- Hardware version (v3 or v3.5 — on the PCB silkscreen).
+- What you did, what you expected, what happened.
+
+Paste on the Tweakers thread or as a GitHub issue. Without telnet
+output, 80% of bug reports get stuck on "please provide more detail".
+
+### Debug command shortcuts
+
+Once connected to telnet:
+
+| Key | Action |
+|---|---|
+| `?` or `h` | Help |
+| `v` | Verbose log level |
+| `d` | Debug log level |
+| `i` | Info log level (default) |
+| `w` | Warnings only |
+| `e` | Errors only |
+| `s` | Toggle silence |
+| `t` | Show uptime (ms) |
+| `m` | Show free heap |
+| `q` | Quit |
+
+---
+
+## 12. Web UI locks out with PIN rate-limit
+
+You got the PIN wrong too many times. Server returns 429 with
+`Retry-After: <seconds>`. Wait it out.
+
+| Consecutive failures | Cooldown |
+|---|---|
+| 1–2 | None |
+| 3 | 10 s |
+| 4 | 60 s |
+| 5 | 5 min |
+| 6+ | 30 min (cap) |
+
+A successful PIN clears the counter. An idle period > 10 minutes also
+clears if no cooldown is active.
+
+If you truly forgot the PIN: set a new one via the LCD menu (physical
+access required). The LCD bypasses the rate limit. If you lost both
+physical access and the PIN, the only recovery is a full firmware
+reflash via USB + factory-reset.
+
+---
+
+## 13. Diagnostics panel shows "Capturing" on every page load
+
+Known-fixed. On recent releases, pressing **Stop** correctly clears the
+diag profile and the panel won't auto-resume.
+
+If you're running an older build: reboot the charger once to clear the
+in-memory profile state, then update to the latest release.
+
+---
+
+## 14. Phase-switching not working (1P ↔ 3P)
+
+On `EnableC2=AUTO`, the charger should drop to 1-phase when solar drops
+below ~4 kW and return to 3-phase when solar exceeds ~4 kW.
+
+| Check | Fix |
+|---|---|
+| C2 contactor physically present | The second contactor is required for phase switching |
+| C2 wired per [guide-installer.md §5](guide-installer.md) | Neutral never switched alone — critical for safety |
+| `EnableC2` set to AUTO (not Always Off / Always On) | Via LCD or Web UI |
+| Car supports on-the-fly phase switching | **Many don't.** Tesla Model 3 MY2019 has documented issues; some Ioniqs and Zoes also |
+| Solar threshold is actually being crossed | Watch Web UI during a cloudy hour |
+
+Car compatibility is a moving target — the
+[Tweakers thread](https://gathering.tweakers.net/forum/list_messages/1648387)
+has current per-model reports from other owners.
+
+---
+
+## 15. Display light stays on after charger "off"
+
+Known behaviour. The LCD backlight is separately controlled and may
+stay on in some idle states. Not a bug — intentional so the device
+appears reachable. If you want it off, set **LCD Backlight** to
+"on during charging only" in the settings.
+
+---
+
+## 16. RFID reader not responding
+
+| Check | Fix |
+|---|---|
+| Reader type set in Web UI | Match the model of your reader |
+| Reader wiring correct | Check power + data lines per reader datasheet |
+| Card enrolled | Add via Web UI → RFID → Add, swipe within window |
+| Access mode not set to "auto" (FreeVend) | In FreeVend any swipe is bypassed — disable FreeVend for strict control |
+
+---
+
+## 17. Nothing above matches
+
+Capture:
+
+1. A telnet log covering the problem (see §11).
+2. `GET /settings` JSON output.
+3. Firmware version.
+4. PCB version (v3 vs v3.5).
+
+File at:
+
+- [GitHub Issues](https://github.com/basmeerman/SmartEVSE-3.5/issues)
+- [Tweakers "Zelfbouw Laadpaal" thread](https://gathering.tweakers.net/forum/list_messages/1648387) (Dutch, maintainers read it)
+
+Clear reproduction steps plus the telnet log is what separates a
+resolved issue from one that sits open for months.


### PR DESCRIPTION
## Summary

Restructures the docs entry point around audience segments. Replaces the kitchen-sink README with a landing page that routes users to audience-specific guides, adds six new guides and a troubleshooting index that curate (not duplicate) the existing topic-organised reference docs.

## Audience segments

Derived from the Dutch Tweakers *Zelfbouw Laadpaal ervaringen* thread (~1M views, 92 pages), the issue trackers, and observed user types:

- **Installer** — has hardware, needs to wire + commission. Previously under-served.
- **Owner** — device installed, daily operator.
- **Integrator** — Home Assistant, REST, OCPP, multi-charger.
- **Contributor** — adds features, fixes bugs.
- **Troubleshooter** — cross-cutting, symptom-indexed.

## Scope

| File | Lines | Status |
|---|---|---|
| `README.md` | 115 | Replaced — segmented landing, AI-methodology moved to one later paragraph |
| `docs/guide-installer.md` | 604 | New — covers ground upstream skips (RCD type selection, silent-coil contactor compatibility, CP cable EMC / shielding, CT orientation check, commissioning without a car) |
| `docs/guide-owner.md` | 474 | New — modes, dashboard legend, RFID, common adjustments, backup |
| `docs/guide-integrator.md` | 449 | New — MQTT / HA, REST, EM_API timing (prevents the \"every 1 second\" myth and 10 s timeout trap), OCPP providers, multi-charger configuration |
| `docs/guide-contributor.md` | 313 | New — architecture, hard rules, test-first workflow, AI-agent contributor notes |
| `docs/troubleshooting.md` | 381 | New — 17 symptom-indexed sections, telnet debug capture for bug reports |
| `docs/security.md` | 289 | New — operator-facing promotion of Plan-16 work (AuthMode, PIN rate limit, CSRF/Origin, session timeout, signed firmware, secret redaction) |
| `docs/documentation-audience-analysis.md` | 354 | New — the plan + locked decisions |

Total: 3,021 lines of new/replaced documentation.

## Design decisions

Captured in `docs/documentation-audience-analysis.md`:

- **Framing:** production-hardened, not AI-engineering-first. Existing `quality.md` keeps the methodology story.
- **Voice:** maintainer typing fast, not polished AI output. Short declarative sentences, tables over prose.
- **Fork/upstream distinction scrubbed** from every audience-facing guide. Users just see \"this firmware\" / \"the charger.\"
- **English only**, with a prominent Tweakers link in the README footer for Dutch community support.
- **Dutch electrical terms as parentheticals** (meterkast, aardlekautomaat) — zero maintenance overhead, helps forum cross-referencing.
- **Car compatibility page** considered then removed per review.

## What this does NOT touch

The existing topic-organised reference docs (installation.md, mqtt-home-assistant.md, REST_API.md, ocpp.md, configuration.md, etc.) are unchanged. The new guides link into them. Reorganising those is out of scope.

## Test plan

- [x] Every internal link between new docs resolves
- [x] No fork/upstream framing in any new audience-facing page
- [x] All \"coming — not yet written\" placeholders replaced with real links
- [x] README table of contents updated
- [ ] Visual review — maintainer opens each guide and confirms tone lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)