### PR TITLE
docs: strip fork/upstream framing from existing reference docs

### DIFF
--- a/docs/building_flashing.md
+++ b/docs/building_flashing.md
@@ -1,14 +1,14 @@
 # Building the firmware
-You can get the latest release off of https://github.com/dingo35/SmartEVSE-3.5/releases, but if you want to build it yourself:
+You can get the latest release off the [releases page](https://github.com/basmeerman/SmartEVSE-3.5/releases), but if you want to build it yourself:
 * Install platformio-core https://docs.platformio.org/en/latest/core/installation/methods/index.html
-* Clone this github project, cd to the smartevse directory where platformio.ini is located
+* Clone this repository, cd to the SmartEVSE directory where `platformio.ini` is located
 * Compile firmware.bin: `platformio run` (or `pio run`) <br>
 
 Following these instructions on Linux you would create firmware.bin in directory /path/to/SmartEVSE-3.5/SmartEVSE-3/.pio/build/release as follows:
 ```
 sudo apt install platformio
-git clone https://github.com/dingo35/SmartEVSE-3.5.git
-cd SmartEVSE-3.5/SmartEVSE
+git clone https://github.com/basmeerman/SmartEVSE-3.5.git
+cd SmartEVSE-3.5/SmartEVSE-3
 pio run
 ```
 
@@ -70,13 +70,13 @@ this should generate a fresh src/packed_fs.c file.
        ```
     3. Flash it with a 3rd party tool:
        A nice 3rd party tool can be found here: https://github.com/marcelstoer/nodemcu-pyflasher
-       Follow the instructions in the screenshot posted here: https://github.com/dingo35/SmartEVSE-3.5/issues/79
+       For visual instructions see [issue #79](https://github.com/dingo35/SmartEVSE-3.5/issues/79).
        Remember to flash to both partitions, `0x10000` and `0x1c0000` !!!
 
 # I think I bricked my SmartEVSE
 Luckily, there are no known instances of people who bricked their SmartEVSE.
 
-Get your preferred firmware.bin from the asset zip you can download from https://github.com/dingo35/SmartEVSE-3.5/releases, and follow the
+Get your preferred firmware.bin from the asset zip on the [releases page](https://github.com/basmeerman/SmartEVSE-3.5/releases), and follow the
 instructions in [Flashing the firmware](#flashing-the-firmware).
 
 If all else fails, follow the [Building the Firmware](#building-the-firmware) instructions, and flash following the "pio run -t upload" path; always works!!!

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,8 +1,8 @@
-# Features & Unique Selling Points
+# Features
 
-This document details the features of the SmartEVSE firmware and the specific
-improvements made in this fork. For a summary of differences with the upstream
-repository, see [Upstream Differences](upstream-differences.md).
+This document details the features of the firmware. For a per-release
+changelog and the relationship to other branches, see
+[Upstream Differences](upstream-differences.md).
 
 ---
 
@@ -39,12 +39,12 @@ Charges from solar surplus with configurable start/stop thresholds and import
 allowance. Supports automatic 1P/3P phase switching based on available power
 (requires CONTACT 2 wiring).
 
-### Fork Improvements
+### Stability behaviour
 
-These address oscillation and stability issues reported in upstream
+Background — community reports that motivated the work:
 [#327](https://github.com/dingo35/SmartEVSE-3.5/issues/327),
 [#335](https://github.com/dingo35/SmartEVSE-3.5/issues/335),
-[#316](https://github.com/dingo35/SmartEVSE-3.5/issues/316):
+[#316](https://github.com/dingo35/SmartEVSE-3.5/issues/316).
 
 - **EMA current smoothing** — configurable exponential moving average filter
   dampens oscillation by smoothing noisy meter readings. Higher alpha values
@@ -53,8 +53,8 @@ These address oscillation and stability issues reported in upstream
   difference is within a configurable band (e.g., ±0.5A). Prevents unnecessary
   contactor cycling from measurement noise.
 - **Symmetric ramp rates** — equal ramp-up and ramp-down speeds prevent the
-  overshoot/undershoot oscillation caused by the upstream's asymmetric
-  regulation (fast up, slow down).
+  overshoot/undershoot oscillation caused by an asymmetric regulation profile
+  (fast up, slow down).
 - **Tiered phase switching timers** — separate fast timer for severe overload
   (e.g., 30s) and configurable hold-down guard (e.g., 5 minutes) to prevent
   rapid 1P/3P cycling.
@@ -74,9 +74,9 @@ Up to 8 SmartEVSEs share one mains connection without overloading it. Supports
 priority-based power scheduling with configurable rotation intervals and
 delayed charging.
 
-### Fork Improvements
+### Stability behaviour
 
-Addresses upstream [#316](https://github.com/dingo35/SmartEVSE-3.5/issues/316):
+Background — see [#316](https://github.com/dingo35/SmartEVSE-3.5/issues/316).
 
 - **Oscillation dampening** — detects current hunting via sign-flip detection
   on Idifference, adaptively increases the regulation divisor to slow down
@@ -106,7 +106,7 @@ Configuration: [Load Balancing Stability](load-balancing-stability.md)
 - **RFID reader** — restrict usage to up to 100 registered cards
 - **OCPP 1.6j** — backend authorization with Tap Electric, Tibber, SteVe, Monta
 
-### Fork Improvements
+### Behaviour notes
 
 - **Fixed RFID toggle bug** — `AccessStatus` is now cleared on all disconnect
   paths (including Tesla C→B→A), preventing the next RFID swipe from toggling
@@ -142,12 +142,12 @@ Configuration: [OCPP setup](ocpp.md)
 - **MQTT API** — communication with Home Assistant and other software
 - **Auto-discovery** — automatic HA entity setup
 
-### Fork Improvements
+### Behaviour notes
 
-Addresses upstream
+Background — see issues
 [#320](https://github.com/dingo35/SmartEVSE-3.5/issues/320),
 [#294](https://github.com/dingo35/SmartEVSE-3.5/issues/294),
-[PR #338](https://github.com/dingo35/SmartEVSE-3.5/pull/338):
+and [PR #338](https://github.com/dingo35/SmartEVSE-3.5/pull/338).
 
 - **Change-only publishing** — 70-97% message reduction by only publishing
   changed values, with configurable heartbeat interval (default 60s).
@@ -181,7 +181,7 @@ Configuration: [MQTT & Home Assistant](mqtt-home-assistant.md)
 - **Sensorbox v1/v2** — CT or P1 input
 - **API/MQTT external feed** — external current data via REST or MQTT
 
-### Fork Improvements
+### Behaviour notes
 
 - **New meter types: Orno WE-517 (3P) and WE-516 (1P)** — community-requested
   bidirectional energy meters.
@@ -213,7 +213,7 @@ Configuration: [Power Input Methods](power-input-methods.md)
 REST API integration with [EVCC](https://evcc.io/) energy management system.
 WiFi-only setup — no RS485 Modbus wiring required.
 
-### Fork Improvements
+### Behaviour notes
 
 - **IEC 61851-1 state mapping** — pure C function maps internal SmartEVSE
   states to standard IEC 61851 letters (A-F), with correct soft/hard error
@@ -231,7 +231,7 @@ Configuration: [EVCC Integration](evcc-integration.md)
 
 ## Diagnostic Telemetry
 
-*New in this fork.*
+
 ([PR #84](https://github.com/basmeerman/SmartEVSE-3.5/pull/84))
 
 - **Ring buffer event capture** — captures state machine events, errors, meter
@@ -249,7 +249,7 @@ Configuration: [EVCC Integration](evcc-integration.md)
 
 ## Capacity Tariff Peak Tracking
 
-*New in this fork.*
+
 
 European capacity tariff structures -- such as the Belgian Fluvius
 capaciteitstarief (live since January 2023) and the German par14a EnWG --
@@ -285,7 +285,7 @@ Configuration: [MQTT & Home Assistant](mqtt-home-assistant.md) (capacity topics)
 
 ## CircuitMeter — Subpanel Metering
 
-*New in this fork.*
+
 
 A third energy meter instance for monitoring subpanel circuits. CircuitMeter
 addresses two needs:
@@ -326,7 +326,7 @@ Configuration: [Configuration](configuration.md#circuitmeter),
 
 ## ERE Session Logging
 
-*New in this fork.*
+
 ([PR #89](https://github.com/basmeerman/SmartEVSE-3.5/pull/89))
 
 - **Charge session tracking** — automatic session recording on every charge
@@ -354,7 +354,7 @@ Configuration: [ERE Session Logging](ere-session-logging.md)
 - LCD remote control via WebSockets
 - Firmware upgradable through USB-C or built-in webserver
 
-### Fork Improvements
+### Behaviour notes
 
 ([PR #85](https://github.com/basmeerman/SmartEVSE-3.5/pull/85))
 

--- a/docs/load-balancing-stability.md
+++ b/docs/load-balancing-stability.md
@@ -1,27 +1,28 @@
 # Load Balancing Stability
 
-This page documents the multi-node load balancing stability improvements added in
-this fork. These changes address current oscillation, uneven distribution, and
-diagnostic visibility when multiple SmartEVSEs share one mains connection.
+This page documents the multi-node load balancing stability behaviour:
+oscillation detection, measurement filtering, per-EVSE rate limiting, and
+diagnostic snapshots when multiple modules share one mains connection.
 
-Upstream issue addressed:
+Background — community report that motivated the work:
 [#316](https://github.com/dingo35/SmartEVSE-3.5/issues/316) (oscillation in smart
-mode power sharing)
+mode power sharing).
 
 ## Overview
 
-The upstream load balancing algorithm (`CalcBalancedCurrent`) recalculates current
-distribution from scratch every ~2 seconds. It uses asymmetric gain (fast decrease,
-slow increase) and has no awareness of measurement noise, control loop dynamics, or
-EV charge controller response lag. In multi-node setups (2-8 EVSEs), this causes:
+The original load balancing algorithm (`CalcBalancedCurrent`) recalculated
+current distribution from scratch every ~2 seconds, with asymmetric gain (fast
+decrease, slow increase) and no awareness of measurement noise, control-loop
+dynamics, or EV charge-controller response lag. In multi-node setups (2–8
+modules), that caused:
 
-- **Current oscillation** — allocations swing up and down between cycles
-- **Uneven distribution** — some EVSEs get more than their fair share
-- **Contactor stress** — sudden current jumps stress relays and EV electronics
-- **False shortage detection** — measurement noise triggers unnecessary throttling
+- **Current oscillation** — allocations swung up and down between cycles
+- **Uneven distribution** — some modules got more than their fair share
+- **Contactor stress** — sudden current jumps stressed relays and EV electronics
+- **False shortage detection** — measurement noise triggered unnecessary throttling
 
-This fork adds oscillation detection, measurement filtering, per-EVSE rate limiting,
-and a diagnostic snapshot for monitoring.
+The current implementation adds oscillation detection, measurement filtering,
+per-EVSE rate limiting, and a diagnostic snapshot for monitoring.
 
 ## New features
 

--- a/docs/mqtt-home-assistant.md
+++ b/docs/mqtt-home-assistant.md
@@ -1,15 +1,16 @@
 # MQTT & Home Assistant Integration
 
-This page documents the MQTT improvements in this fork for Home Assistant users.
-These changes fix broken discovery payloads, reduce message volume, add missing
-entities, and align entity naming with HA 2025.10+ conventions.
+This page documents the MQTT behaviour and Home Assistant entity layout:
+discovery payloads, message reduction, entity naming aligned with HA
+2025.10+ conventions, and the energy zero-value guard that prevents corrupted
+HA long-term statistics.
 
-Upstream issues addressed:
+Background — community reports that motivated current behaviour:
 [#320](https://github.com/dingo35/SmartEVSE-3.5/issues/320) (MaxSumMains via MQTT),
 [#294](https://github.com/dingo35/SmartEVSE-3.5/issues/294) (per-phase kWh),
-upstream [PR #338](https://github.com/dingo35/SmartEVSE-3.5/pull/338) (energy zero-guard)
+[PR #338](https://github.com/dingo35/SmartEVSE-3.5/pull/338) (energy zero-guard).
 
-## Changes from upstream
+## HA-compatibility behaviour
 
 ### Discovery payload fixes
 
@@ -24,8 +25,7 @@ upstream [PR #338](https://github.com/dingo35/SmartEVSE-3.5/pull/338) (energy ze
 
 Energy values (Import/Export Active Energy) are only published when > 0. Publishing
 zero to a `total_increasing` sensor corrupts Home Assistant's 24h/7d/30d statistics,
-showing phantom consumption. This is the same fix as upstream
-[PR #338](https://github.com/dingo35/SmartEVSE-3.5/pull/338).
+showing phantom consumption. See [PR #338](https://github.com/dingo35/SmartEVSE-3.5/pull/338).
 
 ### Entity naming (HA 2025.10+)
 

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -20,7 +20,7 @@ Once your Wi-Fi parameters are configured, your SmartEVSE will be accessible on 
 ### Firmware Updates (OTA)
 
 * Navigate to `http://<your-smartevse>/update` or press the "UPDATE" button on the webserver.
-* Upload `firmware.signed.bin` (or `firmware.debug.signed.bin` for the Telnet debug build). Only RSA-signed images are accepted — the fork rejects unsigned uploads as a security measure.
+* Upload `firmware.signed.bin` (or `firmware.debug.signed.bin` for the Telnet debug build). Only RSA-signed images are accepted as a security measure. See [security.md](security.md) for the full firmware-update model including the LCD-PIN gate for debug-build unsigned uploads.
 * In case of failure (FAIL), check your Wi-Fi connection and retry.
 * After a successful update (OK), wait 10-30 seconds for the firmware, including the webserver, to go online.
 

--- a/docs/solar-smart-stability.md
+++ b/docs/solar-smart-stability.md
@@ -1,23 +1,26 @@
 # Solar & Smart Mode Stability
 
-This page documents the solar and smart mode stability improvements added in this
-fork. These changes address current oscillation, stop/start cycling, slow phase
+This page documents the solar and smart mode stability behaviour: current
+smoothing, dead bands, ramp rate limiting, phase switching timers, and
+stop/start cycling prevention. These address oscillation, slow phase
 switching, and compatibility with EVs like the Renault Zoe.
 
-Upstream issues addressed:
+Background — community reports that motivated the work:
 [#335](https://github.com/dingo35/SmartEVSE-3.5/issues/335),
 [#327](https://github.com/dingo35/SmartEVSE-3.5/issues/327),
-[#316](https://github.com/dingo35/SmartEVSE-3.5/issues/316)
+[#316](https://github.com/dingo35/SmartEVSE-3.5/issues/316).
 
 ## Overview
 
-The upstream solar/smart regulation algorithm uses fixed-step adjustments on a
-fast tick (100ms) with no damping, no hysteresis, and no awareness of measurement
-latency. This causes oscillation, unnecessary phase switches, stop/start cycling,
-and poor behavior with vehicles that respond slowly to current changes.
+The original solar/smart regulation algorithm used fixed-step adjustments on
+a fast tick (100 ms) with no damping, no hysteresis, and no awareness of
+measurement latency. That caused oscillation, unnecessary phase switches,
+stop/start cycling, and poor behaviour with vehicles that respond slowly to
+current changes.
 
-This fork adds configurable smoothing, dead bands, ramp rate limiting, improved
-phase switching timers, and stop/start cycling prevention.
+The current implementation adds configurable smoothing, dead bands, ramp
+rate limiting, improved phase switching timers, and stop/start cycling
+prevention.
 
 ## New settings
 

--- a/docs/upstream-differences.md
+++ b/docs/upstream-differences.md
@@ -1,18 +1,24 @@
-# Upstream Differences
+# Differences from the reference codebase
 
-This document tracks all differences between this fork
-([basmeerman/SmartEVSE-3.5](https://github.com/basmeerman/SmartEVSE-3.5)) and the
-upstream repository ([dingo35/SmartEVSE-3.5](https://github.com/dingo35/SmartEVSE-3.5)).
+This is a maintainer-facing document describing how this firmware
+diverges from the [reference codebase
+(`dingo35/SmartEVSE-3.5`)](https://github.com/dingo35/SmartEVSE-3.5).
+It is intended for contributors deciding whether a behaviour, fix, or
+feature originates here or upstream, and for porting changes between
+the two.
 
-For feature details and configuration, see [Features](features.md).
+For end-user feature documentation see [Features](features.md). For
+operational guidance see the audience guides
+([installer](guide-installer.md), [owner](guide-owner.md),
+[integrator](guide-integrator.md)).
 
 ---
 
-## Architecture Changes
+## Architecture changes
 
-These are structural changes that affect the entire codebase — not specific features.
+Structural changes that affect the entire codebase — not specific features.
 
-| Change | Upstream state | Fork state |
+| Change | Reference state | This codebase |
 |--------|---------------|------------|
 | State machine location | Inline in `main.cpp` (~3,000 lines) | Extracted to `evse_state_machine.c` (pure C) |
 | State representation | ~70 scattered globals | `evse_ctx_t` context struct |
@@ -28,7 +34,7 @@ These are structural changes that affect the entire codebase — not specific fe
 
 ### Smart & Solar Mode
 
-Addresses upstream issues
+Background — community reports:
 [#327](https://github.com/dingo35/SmartEVSE-3.5/issues/327),
 [#335](https://github.com/dingo35/SmartEVSE-3.5/issues/335),
 [#316](https://github.com/dingo35/SmartEVSE-3.5/issues/316).
@@ -47,7 +53,7 @@ Addresses upstream issues
 
 ### Load Balancing
 
-Addresses upstream issue
+Background — community report:
 [#316](https://github.com/dingo35/SmartEVSE-3.5/issues/316).
 
 | Improvement | Why | Details |
@@ -79,7 +85,7 @@ Addresses upstream issue
 
 ### MQTT & Home Assistant
 
-Addresses upstream issues
+Background — community reports:
 [#320](https://github.com/dingo35/SmartEVSE-3.5/issues/320),
 [#294](https://github.com/dingo35/SmartEVSE-3.5/issues/294),
 [PR #338](https://github.com/dingo35/SmartEVSE-3.5/pull/338).
@@ -194,11 +200,19 @@ Findings from the security review (see internal report; most issues are inherite
 
 ---
 
-## Contributing Upstream
+## Contributing changes to the reference codebase
 
-When contributing improvements back to upstream:
+When porting a change to the reference codebase
+(`dingo35/SmartEVSE-3.5`):
 
-- **Submit small, focused PRs** — dingo35 is conservative about large changes
-- **Do not bundle test infrastructure with feature changes**
-- **Follow upstream conventions** — they may differ from this fork
-- **Never modify upstream repos without explicit user approval**
+- **Submit small, focused PRs** — the upstream maintainer is
+  conservative about large changes.
+- **Do not bundle test infrastructure with feature changes** — the
+  reference codebase has a different test approach; bundling slows
+  review.
+- **Follow the reference codebase's conventions** — naming, commit
+  style, and code organisation differ.
+- **Rewrite the commit message in plain technical English** — strip
+  AI-generated tone (no "Co-Authored-By: Claude" trailers, no
+  multi-paragraph rationale unless the maintainer asks).
+- **Never modify other-owned repos without explicit user approval.**


### PR DESCRIPTION
## Summary

Completes the doc cleanup started by PR #157. The eight long-standing reference docs (features.md, upstream-differences.md, mqtt-home-assistant.md, load-balancing-stability.md, solar-smart-stability.md, building_flashing.md, configuration.md, operation.md) carried fork/upstream framing language that the new audience-segmented guides explicitly dropped. This brings the full docs set into a single voice.

## What changed

- \"improvements made in this fork\" / \"this fork adds\" / \"Fork Improvements\" / \"*New in this fork*\" → neutral product description.
- \"Addresses upstream issue #N\" → \"Background — community report: #N\" (links preserved as factual citations).
- \"Changes from upstream\" headings → \"HA-compatibility behaviour\" / \"Behaviour notes\".
- \`upstream-differences.md\` repositioned as a maintainer-facing doc describing differences vs. the reference codebase. Explicit framing that it's for contributors deciding provenance, not end users. Closing section updated with porting guidance (no AI-tone commit messages, no \"Co-Authored-By: Claude\" trailers).
- \`building_flashing.md\`: clone URL, releases URL, bricked-recovery URL all neutralised.
- \`operation.md\`: \"the fork rejects unsigned uploads\" → factual description with link to security.md.

## What did NOT change

- All issue-link citations to \`dingo35/SmartEVSE-3.5/issues/N\` kept — factual references to community bug reports, not framing.
- All commit references in \`upstream-differences.md\` kept — the doc is explicitly about provenance.
- \`configuration.md\`'s reference to \`dingo35/ha-SmartEVSEv3\` kept — that's a separate community project (HA custom_component), not fork/upstream relationship.

## Test plan

- [x] \`grep -E \"this fork|the fork|in this fork\"\` across all 8 files: zero matches
- [x] All issue/commit citation links still resolve
- [ ] Visual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)