### PR TITLE
security(M-6): exponential reconnect backoff for Mongoose MQTT (CWE-799)

### DIFF
--- a/SmartEVSE-3/src/network_common.cpp
+++ b/SmartEVSE-3/src/network_common.cpp
@@ -11,6 +11,7 @@
 #include "glcd.h"
 #include "esp32.h"
 #include "http_api.h"
+#include "reconnect_backoff.h"
 #include <ArduinoJson.h>
 
 #include <HTTPClient.h>
@@ -1023,6 +1024,10 @@ struct mg_str empty = mg_str_n("", 0UL);
 
 #if MQTT && MQTT_ESP == 0
 char s_mqtt_url[80];
+// SECURITY M-6: backoff state for the Mongoose MQTT reconnect path.
+// File-scope static so timer_fn and the MG_EV_CLOSE / MG_EV_MQTT_OPEN
+// branches share one logical instance.
+static reconnect_backoff_t mqtt_backoff = {0};
 //TODO perhaps integrate multiple fn callback functions?
 static void fn_mqtt(struct mg_connection *c, int ev, void *ev_data) {
     if (ev == MG_EV_OPEN) {
@@ -1042,6 +1047,9 @@ static void fn_mqtt(struct mg_connection *c, int ev, void *ev_data) {
         // MQTT connect is successful
         _LOG_V("%lu CONNECTED to %s\n", c->id, s_mqtt_url);
         MQTTclient.connected = true;
+        // SECURITY M-6: clear backoff on successful connection so the next
+        // failure starts at 1 s rather than the prior tier.
+        reconnect_backoff_record_success(&mqtt_backoff);
         SetupMQTTClient();
     } else if (ev == MG_EV_MQTT_MSG) {
         // When we get echo response, print it
@@ -1052,14 +1060,35 @@ static void fn_mqtt(struct mg_connection *c, int ev, void *ev_data) {
         mqtt_receive_callback(topic2, mm->data.buf);
     } else if (ev == MG_EV_CLOSE) {
         _LOG_V("%lu CLOSED\n", c->id);
+        bool was_connected = MQTTclient.connected;
         MQTTclient.connected = false;
         MQTTclient.s_conn = NULL;  // Mark that we're closed
+        // SECURITY M-6: every CLOSE without a successful OPEN counts as a
+        // failed attempt. Arm the backoff so the next timer_fn waits before
+        // retrying. If we were connected (intentional disconnect or broker
+        // dropped a healthy session), don't penalise — record_success was
+        // already called on OPEN, so the backoff state is clean.
+        if (!was_connected) {
+            reconnect_backoff_record_failure(&mqtt_backoff, (uint32_t)millis());
+        }
     }
 }
 
-// Timer function - recreate client connection if it is closed
+// Timer function - recreate client connection if it is closed.
+// SECURITY M-6 (CWE-799): the timer ticks every 3 s but the actual
+// mg_mqtt_connect() call is gated by an exponential backoff. A failing
+// broker no longer triggers a 20-attempts-per-minute storm; the schedule
+// (1 / 2 / 4 / 8 / 16 / 30 s capped) bounds reconnect rate to ~2/min
+// after a few failures, with full reset on a successful connection.
 static void timer_fn(void *arg) {
     struct mg_mgr *mgr = (struct mg_mgr *) arg;
+
+    if (MQTTclient.s_conn != NULL) return;          // already connected / connecting
+    uint32_t now_ms = (uint32_t)millis();
+    if (!reconnect_backoff_should_attempt(&mqtt_backoff, now_ms)) {
+        return;
+    }
+
     struct mg_mqtt_opts opts;
     memset(&opts, 0, sizeof(opts));
     opts.clean = false;
@@ -1078,7 +1107,8 @@ static void timer_fn(void *arg) {
     //mqtt[s]://[username][:password]@host.domain[:port]
     snprintf(s_mqtt_url, sizeof(s_mqtt_url), "mqtt://%s:%i", MQTTHost.c_str(), MQTTPort);
 
-    if (MQTTclient.s_conn == NULL) MQTTclient.s_conn = mg_mqtt_connect(mgr, s_mqtt_url, &opts, fn_mqtt, NULL);
+    reconnect_backoff_record_attempt(&mqtt_backoff, now_ms);
+    MQTTclient.s_conn = mg_mqtt_connect(mgr, s_mqtt_url, &opts, fn_mqtt, NULL);
 }
 #endif
 

--- a/SmartEVSE-3/src/reconnect_backoff.c
+++ b/SmartEVSE-3/src/reconnect_backoff.c
@@ -1,0 +1,72 @@
+/*
+ * reconnect_backoff.c — see reconnect_backoff.h.
+ */
+#include "reconnect_backoff.h"
+
+/* Indexed by consecutive_failures. Index 0 is unused (no backoff at zero
+ * failures). Last entry is the cap and is reused for any larger count. */
+static const uint32_t kBackoffMs[] = {
+    0,                  /* 0 failures — unused */
+    1UL * 1000UL,       /* 1 failure  → 1 s */
+    2UL * 1000UL,       /* 2 failures → 2 s */
+    4UL * 1000UL,       /* 3 failures → 4 s */
+    8UL * 1000UL,       /* 4 failures → 8 s */
+    16UL * 1000UL,      /* 5 failures → 16 s */
+    30UL * 1000UL       /* 6+ failures → 30 s cap */
+};
+#define BACKOFF_TABLE_LEN ((uint8_t)(sizeof(kBackoffMs) / sizeof(kBackoffMs[0])))
+#define BACKOFF_CAP_INDEX ((uint8_t)(BACKOFF_TABLE_LEN - 1))
+
+static uint32_t backoff_for_count(uint8_t fail_count) {
+    if (fail_count >= BACKOFF_TABLE_LEN) fail_count = BACKOFF_CAP_INDEX;
+    return kBackoffMs[fail_count];
+}
+
+bool reconnect_backoff_should_attempt(const reconnect_backoff_t *state,
+                                      uint32_t now_ms) {
+    if (!state) return true;                            /* fail-open */
+    if (state->next_attempt_ms == 0) return true;       /* no backoff active */
+    /* Wrap-safe compare: (now - next) treated as signed; >=0 means now is at or past next. */
+    return (int32_t)(now_ms - state->next_attempt_ms) >= 0;
+}
+
+void reconnect_backoff_record_attempt(reconnect_backoff_t *state,
+                                      uint32_t now_ms) {
+    (void)state;
+    (void)now_ms;
+    /* Currently a no-op; reserved for future telemetry. State changes
+     * happen in record_success / record_failure based on the outcome. */
+}
+
+void reconnect_backoff_record_success(reconnect_backoff_t *state) {
+    if (!state) return;
+    state->consecutive_failures = 0;
+    state->next_attempt_ms = 0;
+}
+
+void reconnect_backoff_record_failure(reconnect_backoff_t *state,
+                                      uint32_t now_ms) {
+    if (!state) return;
+
+    /* Saturating increment to keep the counter sane even after extended
+     * outages — the cap entry in kBackoffMs handles any value above the
+     * table length anyway, but a clamp avoids debugger-confusing overflows. */
+    if (state->consecutive_failures < 0xFFu) {
+        state->consecutive_failures++;
+    }
+
+    uint32_t delay = backoff_for_count(state->consecutive_failures);
+    state->next_attempt_ms = now_ms + delay;
+    /* Guard the zero sentinel — if the addition wrapped to exactly 0, bump
+     * to 1 so should_attempt() correctly recognises an active cooldown. */
+    if (state->next_attempt_ms == 0) state->next_attempt_ms = 1;
+}
+
+uint32_t reconnect_backoff_seconds_until_next(const reconnect_backoff_t *state,
+                                              uint32_t now_ms) {
+    if (!state || state->next_attempt_ms == 0) return 0;
+    int32_t delta = (int32_t)(state->next_attempt_ms - now_ms);
+    if (delta <= 0) return 0;
+    /* Round up to whole seconds so reports never under-promise the wait. */
+    return (uint32_t)((delta + 999) / 1000);
+}

--- a/SmartEVSE-3/src/reconnect_backoff.h
+++ b/SmartEVSE-3/src/reconnect_backoff.h
@@ -1,0 +1,77 @@
+/*
+ * reconnect_backoff.h — exponential backoff for MQTT / WebSocket reconnects.
+ *
+ * Pure C, allocation-free, testable natively.
+ *
+ * Threat model (security finding M-6, CWE-799 — uncontrolled resource
+ * consumption): a failing backend (broker offline, network partition,
+ * DNS failure) currently triggers a constant 3-second reconnect storm
+ * from the Mongoose MQTT timer. This wastes CPU, fills logs, and on a
+ * shared upstream network can DoS the broker.
+ *
+ * Schedule:
+ *   failure 1:  1 s before next attempt
+ *   failure 2:  2 s
+ *   failure 3:  4 s
+ *   failure 4:  8 s
+ *   failure 5: 16 s
+ *   failure 6+: 30 s (capped)
+ *
+ *   On a successful connection, the failure counter is cleared and the
+ *   next failure starts at 1 s again.
+ */
+#ifndef RECONNECT_BACKOFF_H
+#define RECONNECT_BACKOFF_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint8_t  consecutive_failures;  /* Saturating counter; capped internally. */
+    uint32_t next_attempt_ms;       /* millis() at which next attempt is allowed. 0 = no backoff active. */
+} reconnect_backoff_t;
+
+/*
+ * True when an attempt is allowed at the current millis() — either because
+ * no backoff is active (clean state) or because the cooldown has elapsed.
+ * Pure inspection; does not mutate state. The caller must call
+ * reconnect_backoff_record_attempt() before actually attempting.
+ */
+bool reconnect_backoff_should_attempt(const reconnect_backoff_t *state, uint32_t now_ms);
+
+/*
+ * Mark that an attempt is being made now. Call this *before* the actual
+ * connect call. If the caller skips this and just calls _record_failure /
+ * _record_success the schedule still works; this exists for symmetry and
+ * to allow future telemetry hooks.
+ */
+void reconnect_backoff_record_attempt(reconnect_backoff_t *state, uint32_t now_ms);
+
+/*
+ * Connection succeeded — reset counter and clear any pending cooldown.
+ */
+void reconnect_backoff_record_success(reconnect_backoff_t *state);
+
+/*
+ * Connection attempt failed — increment the counter (saturating) and
+ * arm the next-attempt timestamp per the schedule above.
+ */
+void reconnect_backoff_record_failure(reconnect_backoff_t *state, uint32_t now_ms);
+
+/*
+ * Whole seconds remaining on the current cooldown, or 0 if none. Suitable
+ * for log messages or status reporting; rounds up so 1 ms remaining shows
+ * as 1 s, not 0 s.
+ */
+uint32_t reconnect_backoff_seconds_until_next(const reconnect_backoff_t *state,
+                                              uint32_t now_ms);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RECONNECT_BACKOFF_H */

--- a/SmartEVSE-3/test/native/Makefile
+++ b/SmartEVSE-3/test/native/Makefile
@@ -110,6 +110,9 @@ $(BUILD)/test_http_auth: $(TEST_DIR)/test_http_auth.c $(SRC_DIR)/http_auth.c $(S
 $(BUILD)/test_pin_rate_limit: $(TEST_DIR)/test_pin_rate_limit.c $(SRC_DIR)/pin_rate_limit.c $(SRC_DIR)/pin_rate_limit.h include/*.h | $(BUILD)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $(TEST_DIR)/test_pin_rate_limit.c $(SRC_DIR)/pin_rate_limit.c
 
+$(BUILD)/test_reconnect_backoff: $(TEST_DIR)/test_reconnect_backoff.c $(SRC_DIR)/reconnect_backoff.c $(SRC_DIR)/reconnect_backoff.h include/*.h | $(BUILD)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $(TEST_DIR)/test_reconnect_backoff.c $(SRC_DIR)/reconnect_backoff.c
+
 $(BUILD)/test_solar_debug_json: $(TEST_DIR)/test_solar_debug_json.c $(SOLAR_DEBUG_JSON_SRC) $(SRC_DIR)/solar_debug_json.h include/*.h | $(BUILD)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $(TEST_DIR)/test_solar_debug_json.c $(SOLAR_DEBUG_JSON_SRC)
 

--- a/SmartEVSE-3/test/native/tests/test_reconnect_backoff.c
+++ b/SmartEVSE-3/test/native/tests/test_reconnect_backoff.c
@@ -1,0 +1,170 @@
+/*
+ * test_reconnect_backoff.c — tests for the MQTT/WebSocket reconnect backoff.
+ * See src/reconnect_backoff.h.
+ */
+#include "test_framework.h"
+#include "reconnect_backoff.h"
+
+/* ---- Clean state ---- */
+
+/*
+ * @feature Reconnect backoff
+ * @req REQ-NET-010
+ * @scenario Clean state allows immediate attempt
+ */
+void test_clean_state_allows(void) {
+    reconnect_backoff_t s = {0};
+    TEST_ASSERT_TRUE(reconnect_backoff_should_attempt(&s, 1000));
+    TEST_ASSERT_EQUAL_INT(0, (int)reconnect_backoff_seconds_until_next(&s, 1000));
+}
+
+/* ---- Schedule ---- */
+
+/*
+ * @feature Reconnect backoff
+ * @req REQ-NET-011
+ * @scenario First failure arms 1-second backoff
+ */
+void test_first_failure_1s(void) {
+    reconnect_backoff_t s = {0};
+    reconnect_backoff_record_failure(&s, 1000);
+    TEST_ASSERT_FALSE(reconnect_backoff_should_attempt(&s, 1000));
+    TEST_ASSERT_EQUAL_INT(1, (int)reconnect_backoff_seconds_until_next(&s, 1000));
+    /* After 1s, attempt allowed. */
+    TEST_ASSERT_TRUE(reconnect_backoff_should_attempt(&s, 2000));
+}
+
+/*
+ * @feature Reconnect backoff
+ * @req REQ-NET-011
+ * @scenario Each subsequent failure doubles the backoff up to 30 s cap
+ */
+void test_doubling_schedule(void) {
+    reconnect_backoff_t s = {0};
+    /* Drive one failure at a time and check the cooldown each step. */
+    const uint32_t expected[] = {1, 2, 4, 8, 16, 30, 30, 30};
+    for (uint32_t i = 0; i < sizeof(expected) / sizeof(expected[0]); i++) {
+        /* Use a millis() sequence comfortably past prior cooldowns. */
+        uint32_t t = 1000000UL + i * 100000UL;
+        reconnect_backoff_record_failure(&s, t);
+        TEST_ASSERT_EQUAL_INT((int)expected[i],
+            (int)reconnect_backoff_seconds_until_next(&s, t));
+    }
+}
+
+/* ---- Success clears state ---- */
+
+/*
+ * @feature Reconnect backoff
+ * @req REQ-NET-012
+ * @scenario Success clears the failure counter and the cooldown
+ */
+void test_success_clears(void) {
+    reconnect_backoff_t s = {0};
+    reconnect_backoff_record_failure(&s, 1000);
+    reconnect_backoff_record_failure(&s, 1000);
+    reconnect_backoff_record_failure(&s, 1000);
+    TEST_ASSERT_FALSE(reconnect_backoff_should_attempt(&s, 1500));
+    reconnect_backoff_record_success(&s);
+    TEST_ASSERT_TRUE(reconnect_backoff_should_attempt(&s, 1500));
+    TEST_ASSERT_EQUAL_INT(0, (int)s.consecutive_failures);
+    /* Next failure starts at 1 s again, not at the previous level. */
+    reconnect_backoff_record_failure(&s, 5000);
+    TEST_ASSERT_EQUAL_INT(1, (int)reconnect_backoff_seconds_until_next(&s, 5000));
+}
+
+/* ---- Cooldown elapses ---- */
+
+/*
+ * @feature Reconnect backoff
+ * @req REQ-NET-013
+ * @scenario After cooldown elapses, attempts allowed without state mutation
+ * @given A 4-second cooldown after 3 failures
+ * @when should_attempt is called past the cooldown deadline
+ * @then Returns true; counter unchanged (only failure or success mutates)
+ */
+void test_cooldown_elapses(void) {
+    reconnect_backoff_t s = {0};
+    reconnect_backoff_record_failure(&s, 1000);
+    reconnect_backoff_record_failure(&s, 1000);
+    reconnect_backoff_record_failure(&s, 1000);   /* 4 s cooldown until 5000 */
+    TEST_ASSERT_FALSE(reconnect_backoff_should_attempt(&s, 4000));
+    TEST_ASSERT_TRUE(reconnect_backoff_should_attempt(&s, 5500));
+    /* Counter not reset — that only happens on success. Schedule on next
+     * failure escalates from 4 → 8 s. */
+    TEST_ASSERT_EQUAL_INT(3, (int)s.consecutive_failures);
+    reconnect_backoff_record_failure(&s, 5500);
+    TEST_ASSERT_EQUAL_INT(8, (int)reconnect_backoff_seconds_until_next(&s, 5500));
+}
+
+/* ---- Rounding ---- */
+
+/*
+ * @feature Reconnect backoff
+ * @req REQ-NET-014
+ * @scenario seconds_until_next rounds up
+ */
+void test_seconds_rounds_up(void) {
+    reconnect_backoff_t s = {0};
+    reconnect_backoff_record_failure(&s, 1000);            /* cooldown 1000 → 2000 */
+    TEST_ASSERT_EQUAL_INT(1, (int)reconnect_backoff_seconds_until_next(&s, 1000));
+    /* 999 ms left → 1 s, not 0 s. */
+    TEST_ASSERT_EQUAL_INT(1, (int)reconnect_backoff_seconds_until_next(&s, 1001));
+    /* 1 ms left → 1 s. */
+    TEST_ASSERT_EQUAL_INT(1, (int)reconnect_backoff_seconds_until_next(&s, 1999));
+    /* Past deadline → 0 s. */
+    TEST_ASSERT_EQUAL_INT(0, (int)reconnect_backoff_seconds_until_next(&s, 2500));
+}
+
+/* ---- NULL safety / fail-open ---- */
+
+/*
+ * @feature Reconnect backoff
+ * @req REQ-NET-015
+ * @scenario NULL state is safe and fails open
+ */
+void test_null_safe(void) {
+    TEST_ASSERT_TRUE(reconnect_backoff_should_attempt(NULL, 1000));
+    TEST_ASSERT_EQUAL_INT(0, (int)reconnect_backoff_seconds_until_next(NULL, 1000));
+    /* These should not crash. */
+    reconnect_backoff_record_attempt(NULL, 1000);
+    reconnect_backoff_record_success(NULL);
+    reconnect_backoff_record_failure(NULL, 1000);
+}
+
+/* ---- Counter saturation ---- */
+
+/*
+ * @feature Reconnect backoff
+ * @req REQ-NET-016
+ * @scenario consecutive_failures saturates at 0xFF
+ */
+void test_counter_saturates(void) {
+    reconnect_backoff_t s = {0};
+    s.consecutive_failures = 0xFFu;
+    reconnect_backoff_record_failure(&s, 1000);
+    TEST_ASSERT_EQUAL_INT(0xFFu, s.consecutive_failures);
+    /* Cooldown is still the cap value (30 s). */
+    TEST_ASSERT_EQUAL_INT(30, (int)reconnect_backoff_seconds_until_next(&s, 1000));
+}
+
+int main(void) {
+    TEST_SUITE_BEGIN("Reconnect Backoff");
+
+    RUN_TEST(test_clean_state_allows);
+
+    RUN_TEST(test_first_failure_1s);
+    RUN_TEST(test_doubling_schedule);
+
+    RUN_TEST(test_success_clears);
+
+    RUN_TEST(test_cooldown_elapses);
+
+    RUN_TEST(test_seconds_rounds_up);
+
+    RUN_TEST(test_null_safe);
+
+    RUN_TEST(test_counter_saturates);
+
+    TEST_SUITE_RESULTS();
+}


### PR DESCRIPTION
## Summary

Closes the M-6 finding — uncontrolled resource consumption on failed MQTT reconnects.

## Before

\`timer_fn()\` ticked every 3 seconds and unconditionally called \`mg_mqtt_connect()\` whenever the connection was down. A failing broker triggered 20 connection attempts per minute indefinitely. Wastes CPU, fills logs, and on a shared upstream network can DoS the broker.

## After

Pure-C exponential backoff helper (\`reconnect_backoff.c/h\`) gates the connect call. Schedule:

| Consecutive failures | Wait before next attempt |
|---|---|
| 1 | 1 s |
| 2 | 2 s |
| 3 | 4 s |
| 4 | 8 s |
| 5 | 16 s |
| 6+ | 30 s (cap) |

Successful connection clears the counter so the next failure starts fresh. Worst-case steady-state retry rate after a few failures drops from 20/min to ~2/min.

## Wiring

- \`timer_fn()\` consults \`reconnect_backoff_should_attempt()\` before calling \`mg_mqtt_connect()\` and records the attempt afterwards.
- \`MG_EV_MQTT_OPEN\` handler calls \`reconnect_backoff_record_success()\`.
- \`MG_EV_CLOSE\` handler calls \`reconnect_backoff_record_failure()\`, but only if \`MQTTclient.connected\` was false (i.e. the connect attempt failed before OPEN fired). An intentional disconnect from a healthy session does not penalise the backoff.

## Scope notes

- Mongoose MQTT path (\`MQTT_ESP=0\`, the default for ESP32 v3) was the vulnerable code and is the target of this PR.
- ESP-IDF MQTT path (\`MQTT_ESP=1\`) uses the library's built-in \`reconnect_timeout_ms\` which is already rate-limited at the library layer.
- OCPP WebSocket reconnect is handled by the MicroOcpp library; the application-layer silence-detection forced reconnect at \`esp32.cpp:2295\` is already throttled by the \`OcppLastOcppResponse\` reset on every forced reconnect.

## Tests

8 SbE tests (REQ-NET-010..016): clean-state allow, each backoff tier, doubling schedule, 30 s cap, success-clears, cooldown-elapses semantics, seconds rounding, NULL-safe fail-open, counter saturation.

## Verification

- Native tests: 54/54 (was 53)
- Sanitizers (ASan + UBSan): 54/54
- cppcheck clean on \`reconnect_backoff.c\`
- \`pio run -e release\`: OK (flash 86.6%)

Closes task #48 and completes the M-2 / M-6 / M-7 cleanup series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)